### PR TITLE
Fix TWLBot releases not having messages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
           echo ::set-output name=author_name::$(git log -1 "$GITHUB_SHA" --pretty="%aN")
           echo ::set-output name=committer_name::$(git log -1 "$GITHUB_SHA" --pretty="%cN")
           echo ::set-output name=commit_subject::$(git log -1 "$GITHUB_SHA" --pretty="%s")
-          echo ::set-output name=commit_message::$(git log -1 "$GITHUB_SHA" --pretty="%b")
+          echo ::set-output name=commit_message::$(git log -1 "$GITHUB_SHA" --pretty="%B")
       - name: Pack 7z nightly
         if: ${{ !startsWith(github.ref, 'refs/tags') }}
         run: |


### PR DESCRIPTION
Same as DS-Homebrew/TWiLightMenu#1384, simply fixes the git command for the TWLBot releases' messages being `%b` instead of `%B