### PR TITLE
Don't wait 25 frames before showing menu

### DIFF
--- a/retail/cardenginei/arm7/source/inGameMenu.c
+++ b/retail/cardenginei/arm7/source/inGameMenu.c
@@ -47,9 +47,6 @@ void inGameMenu(void) {
 	}
 
 	while (sharedAddr[4] == 0x554E454D) {
-		while (REG_VCOUNT != 191);
-		while (REG_VCOUNT == 191);
-
 		sharedAddr[5] = ~REG_KEYINPUT & 0x3FF;
 		sharedAddr[5] |= (~REG_EXTKEYINPUT & 0x3) << 10;
 		timeTilBatteryLevelRefresh++;
@@ -57,6 +54,9 @@ void inGameMenu(void) {
 			*(u8*)(INGAME_MENU_LOCATION+0x9FFF) = i2cReadRegister(I2C_PM, I2CREGPM_BATTERY);
 			timeTilBatteryLevelRefresh = 0;
 		}
+
+		while (REG_VCOUNT != 191);
+		while (REG_VCOUNT == 191);
 	}
 
 	switch (sharedAddr[4]) {

--- a/retail/cardenginei/arm9_igm/source/inGameMenu.c
+++ b/retail/cardenginei/arm9_igm/source/inGameMenu.c
@@ -115,7 +115,7 @@ static void printBattery(void) {
 
 static void waitKeys(u16 keys) {
 	// Prevent key repeat for 10 frames
-	for(int i = 0; i < 10 && KEYS; i++) {
+	for(int i = 0; i < 10 && (KEYS & keys); i++) {
 		while (REG_VCOUNT != 191);
 		while (REG_VCOUNT == 191);
 	}
@@ -128,7 +128,7 @@ static void waitKeys(u16 keys) {
 
 static void waitKeysBattery(u16 keys) {
 	// Prevent key repeat for 10 frames
-	for(int i = 0; i < 10 && KEYS; i++) {
+	for(int i = 0; i < 10 && (KEYS & keys); i++) {
 		printBattery();
 		while (REG_VCOUNT != 191);
 		while (REG_VCOUNT == 191);
@@ -409,17 +409,22 @@ void inGameMenu(s8* mainScreen) {
 	tonccpy(bgBak, BG_GFX_SUB, FONT_SIZE);	// Backup the original graphics
 	tonccpy(BG_GFX_SUB, font_bin, FONT_SIZE); // Load font
 
-	// Wait some frames so the key check is ready
-	for (int i = 0; i < 25; i++) {
+	// Let ARM7 know the menu loaded
+	sharedAddr[5] = 0x59444552; // 'REDY'
+
+	// Wait for keys to be released
+	drawMainMenu();
+	drawCursor(0);
+	do {
+		printBattery();
 		while (REG_VCOUNT != 191);
 		while (REG_VCOUNT == 191);
-	}
+	} while(KEYS & (KEY_DOWN | KEY_L | KEY_SELECT));
 
 	u8 cursorPosition = 0;
 	while (sharedAddr[4] == 0x554E454D) {
 		drawMainMenu();
 		drawCursor(cursorPosition);
-		sharedAddr[5] = 0x59444552; // 'REDY'
 
 		waitKeysBattery(KEY_UP | KEY_DOWN | KEY_A | KEY_B);
 


### PR DESCRIPTION
#### What's changed?

- Removes unneccessary 25 frame wait when opening the in-game menu
- Also makes it ignore input until Down + L + SELECT is released
- And makes waitKeys() not wait for non-specified keys

#### Where have you tested it?

- DSi (K) from Unlaunch

---

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.