### PR TITLE
Make in-game menu hotkey customizable

### DIFF
--- a/retail/arm9/include/configuration.h
+++ b/retail/arm9/include/configuration.h
@@ -51,6 +51,7 @@ typedef struct configuration {
 	bool gameOnFlashcard;
 	bool saveOnFlashcard;
 	bool macroMode;
+	u16 hotkey;
 } configuration;
 
 #endif // CONFIGURATION_H

--- a/retail/arm9/source/conf_sd.cpp
+++ b/retail/arm9/source/conf_sd.cpp
@@ -177,6 +177,9 @@ static void load_conf(configuration* conf, const char* fn) {
 
 	// GUI Language
 	conf->guiLanguage = strdup(config_file.fetch("NDS-BOOTSTRAP", "GUI_LANGUAGE").c_str());
+
+	// Hotkey
+	conf->hotkey = strtol(config_file.fetch("NDS-BOOTSTRAP", "HOTKEY").c_str(), NULL, 16);
 }
 
 int loadFromSD(configuration* conf, const char *bootstrapPath) {
@@ -460,6 +463,9 @@ int loadFromSD(configuration* conf, const char *bootstrapPath) {
 		tonccpy(igmText->version, VER_NUMBER, sizeof(VER_NUMBER));
 		tonccpy(igmText->ndsBootstrap, u"nds-bootstrap", 28);
 		igmText->rtl = strcmp(conf->guiLanguage, "he") == 0;
+
+		// Set In-Game Menu hotkey
+		igmText->hotkey = conf->hotkey != 0 ? conf->hotkey : (KEY_L | KEY_DOWN | KEY_SELECT);
 
 		char path[40];
 		snprintf(path, sizeof(path), "nitro:/languages/%s/in_game_menu.ini", conf->guiLanguage);

--- a/retail/cardenginei/arm7/source/cardengine.c
+++ b/retail/cardenginei/arm7/source/cardengine.c
@@ -37,6 +37,7 @@
 #include "debug_file.h"
 #include "cardengine.h"
 #include "nds_header.h"
+#include "igm_text.h"
 
 #include "sr_data_error.h"      // For showing an error screen
 #include "sr_data_srloader.h"   // For rebooting into TWiLight Menu++
@@ -799,7 +800,7 @@ void myIrqHandlerVBlank(void) {
 		swapTimer = 0;
 	}
 	
-	if ( 0 == (REG_KEYINPUT & (KEY_L | KEY_DOWN | KEY_SELECT))) {
+	if (0 == (REG_KEYINPUT & igmText->hotkey) && 0 == (REG_EXTKEYINPUT & (((igmText->hotkey >> 10) & 3) | ((igmText->hotkey >> 6) & 0xC0)))) {
 		((valueBits & extendedMemory) || (ndsHeader->unitCode > 0 && (valueBits & dsiMode))) ? returnToLoader() : inGameMenu();
 	}
 

--- a/retail/cardenginei/arm7/source/inGameMenu.c
+++ b/retail/cardenginei/arm7/source/inGameMenu.c
@@ -48,7 +48,7 @@ void inGameMenu(void) {
 
 	while (sharedAddr[4] == 0x554E454D) {
 		sharedAddr[5] = ~REG_KEYINPUT & 0x3FF;
-		sharedAddr[5] |= (~REG_EXTKEYINPUT & 0x3) << 10;
+		sharedAddr[5] |= ((~REG_EXTKEYINPUT & 0x3) << 10) | ((~REG_EXTKEYINPUT & 0xC0) << 6);
 		timeTilBatteryLevelRefresh++;
 		if (timeTilBatteryLevelRefresh == 8) {
 			*(u8*)(INGAME_MENU_LOCATION+0x9FFF) = i2cReadRegister(I2C_PM, I2CREGPM_BATTERY);

--- a/retail/cardenginei/arm9_igm/source/inGameMenu.c
+++ b/retail/cardenginei/arm9_igm/source/inGameMenu.c
@@ -419,7 +419,7 @@ void inGameMenu(s8* mainScreen) {
 		printBattery();
 		while (REG_VCOUNT != 191);
 		while (REG_VCOUNT == 191);
-	} while(KEYS & (KEY_DOWN | KEY_L | KEY_SELECT));
+	} while(KEYS & igmText->hotkey);
 
 	u8 cursorPosition = 0;
 	while (sharedAddr[4] == 0x554E454D) {

--- a/retail/common/include/igm_text.h
+++ b/retail/common/include/igm_text.h
@@ -11,6 +11,7 @@ struct IgmText {
 	u16 menu[6][20];
 	u16 options[10][20];
 	bool rtl;
+	u16 hotkey;
 };
 
 struct IgmText *igmText = (struct IgmText *)INGAME_MENU_LOCATION;


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

Lets you set the in-game menu hotkey from the `nds-bootstrap.ini`. I would add setting it to the menu but as it can't save those settings there's not much point, better to make it be set from TWiLight / manually.

I'll probably do another PR in a bit to TWiLight to add an option to TWiLight settings for the nds-bootstrap hotkey and make it either let you set something custom or just choose from a few presets like L + Down + SELECT, A + B + X + Y, etc depending on how easy custom ones are to do.

It's just a base-16 number of the libnds keys, so: (the 0x and start padding 0s are optional)
```
     A: 0x0001
     B: 0x0002
SELECT: 0x0004
 START: 0x0008
 Right: 0x0010
  Left: 0x0020
    Up: 0x0040
  Down: 0x0080
     R: 0x0100
     L: 0x0200
     X: 0x0400
     Y: 0x0800
 Touch: 0x1000
   Lid: 0x2000
```

Ex. `0x0C03` is A + B + X + Y, `0x1001` is touch + A, `0x0284` is L + Down + SELECT, etc

One thing that could potentially cause problems is that I just put the hotkey in the in-game menu text struct as that's an easy way to get info to the cardengine, at the moment this appears to be in shared RAM between ARM7 and ARM9 so both can read the hotkey no problem, however if there's a chance of that being moved then this may not be a good location.

#### Where have you tested it?

- DSi LL (J) from Unlaunch

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
