### PR TITLE
Add stepping 1 frame with R in menu

### DIFF
--- a/retail/cardenginei/arm7/source/cardengine.c
+++ b/retail/cardenginei/arm7/source/cardengine.c
@@ -134,6 +134,8 @@ static bool volumeAdjustActivated = false;
 static int cardEgnineCommandMutex = 0;
 static int saveMutex = 0;
 
+bool returnToMenu = false;
+
 #ifdef TWLSDK
 static const tNDSHeader* ndsHeader = (tNDSHeader*)NDS_HEADER_SDK5;
 static PERSONAL_DATA* personalData = (PERSONAL_DATA*)((u8*)NDS_HEADER_SDK5-0x180);
@@ -815,7 +817,7 @@ void myIrqHandlerVBlank(void) {
 		i2cWriteRegister(0x4A, 0x11, 0x01);		// Reboot into error screen if SD card is removed
 	}
 
-	if (0 == (REG_KEYINPUT & igmHotkey) && 0 == (REG_EXTKEYINPUT & (((igmHotkey >> 10) & 3) | ((igmHotkey >> 6) & 0xC0)))) {
+	if ((0 == (REG_KEYINPUT & igmHotkey) && 0 == (REG_EXTKEYINPUT & (((igmHotkey >> 10) & 3) | ((igmHotkey >> 6) & 0xC0)))) || returnToMenu) {
 		((valueBits & extendedMemory) || (ndsHeader->unitCode > 0 && (valueBits & dsiMode))) ? returnToLoader() : inGameMenu();
 	}
 

--- a/retail/cardenginei/arm7/source/inGameMenu.c
+++ b/retail/cardenginei/arm7/source/inGameMenu.c
@@ -9,9 +9,10 @@
 #include "cardengine.h"
 #include "nds_header.h"
 
-#define	REG_EXTKEYINPUT	(*(vuint16*)0x04000136)
+#define REG_EXTKEYINPUT (*(vuint16*)0x04000136)
 
 extern vu32* volatile sharedAddr;
+extern bool returnToMenu;
 
 extern void forceGameReboot(void);
 extern void dumpRam(void);
@@ -21,6 +22,7 @@ extern void saveScreenshot(void);
 volatile int timeTilBatteryLevelRefresh = 7;
 
 void inGameMenu(void) {
+	returnToMenu = false;
 	sharedAddr[4] = 0x554E454D; // 'MENU'
 	IPC_SendSync(0x9);
 	REG_MASTER_VOLUME = 0;
@@ -39,40 +41,43 @@ void inGameMenu(void) {
 	}
 
 	if (sharedAddr[4] == 0x554E454D) {
-	  while (1) {
-		sharedAddr[5] = ~REG_KEYINPUT & 0x3FF;
-		sharedAddr[5] |= ((~REG_EXTKEYINPUT & 0x3) << 10) | ((~REG_EXTKEYINPUT & 0xC0) << 6);
-		timeTilBatteryLevelRefresh++;
-		if (timeTilBatteryLevelRefresh == 8) {
-			*(u8*)(INGAME_MENU_LOCATION+0x9FFF) = i2cReadRegister(I2C_PM, I2CREGPM_BATTERY);
-			timeTilBatteryLevelRefresh = 0;
-		}
+		while (1) {
+			sharedAddr[5] = ~REG_KEYINPUT & 0x3FF;
+			sharedAddr[5] |= ((~REG_EXTKEYINPUT & 0x3) << 10) | ((~REG_EXTKEYINPUT & 0xC0) << 6);
+			timeTilBatteryLevelRefresh++;
+			if (timeTilBatteryLevelRefresh == 8) {
+				*(u8*)(INGAME_MENU_LOCATION+0x9FFF) = i2cReadRegister(I2C_PM, I2CREGPM_BATTERY);
+				timeTilBatteryLevelRefresh = 0;
+			}
 
-		while (REG_VCOUNT != 191);
-		while (REG_VCOUNT == 191);
+			while (REG_VCOUNT != 191);
+			while (REG_VCOUNT == 191);
 
-		switch (sharedAddr[4]) {
-			case 0x54495845: // EXIT
-			default:
+			switch (sharedAddr[4]) {
+				case 0x54495845: // EXIT
+				default:
+					break;
+				case 0x54455352: // RSET
+					forceGameReboot();
+					break;
+				case 0x54495551: // QUIT
+					returnToLoader();
+					break;
+				case 0x444D4152: // RAMD
+					dumpRam();
+					break;
+				case 0x544F4853: // SHOT
+					saveScreenshot();
+					sharedAddr[4] = 0x554E454D;
+					break;
+				case 0x50455453: // STEP
+					returnToMenu = true;
+					break;
+			}
+			if (sharedAddr[4] != 0x554E454D) {
 				break;
-			case 0x54455352: // RSET
-				forceGameReboot();
-				break;
-			case 0x54495551: // QUIT
-				returnToLoader();
-				break;
-			case 0x444D4152: // RAMD
-				dumpRam();
-				break;
-			case 0x544F4853: // SHOT
-				saveScreenshot();
-				sharedAddr[4] = 0x554E454D;
-				break;
+			}
 		}
-		if (sharedAddr[4] != 0x554E454D) {
-			break;
-		}
-	  }
 	}
 
 	sharedAddr[4] = 0x54495845; // EXIT

--- a/retail/cardenginei/arm9_igm/source/inGameMenu.c
+++ b/retail/cardenginei/arm9_igm/source/inGameMenu.c
@@ -196,15 +196,25 @@ static void screenshot(void) {
 		vramBank = cursorPosition;
 
 		clearScreen();
+
 		toncset16(BG_MAP_RAM_SUB(9) + 0x20 * 9 + 5, '-', 20);
 		printCenter(15, 10, igmText->selectBank, 0);
 		printChar(15, 12, 'A' + vramBank, 3);
 		toncset16(BG_MAP_RAM_SUB(9) + 0x20 * 13 + 5, '-', 20);
-		print(6, 14, igmText->count, 0);
+
 		u8 color = igmText->currentScreenshot == 50 ? 4 : 5;
-		printDec(19, 14, igmText->currentScreenshot, 2, color);
-		printChar(21, 14, '/', color);
-		printDec(22, 14, 50, 2, color);
+		if(igmText->rtl) {
+			printDec(6, 14, igmText->currentScreenshot, 2, color);
+			printChar(8, 14, '/', color);
+			printDec(9, 14, 50, 2, color);
+			printRight(23, 14, igmText->count, 0);
+		} else {
+			print(6, 14, igmText->count, 0);
+			printDec(19, 14, igmText->currentScreenshot, 2, color);
+			printChar(21, 14, '/', color);
+			printDec(22, 14, 50, 2, color);
+
+		}
 
 		waitKeys(KEY_UP | KEY_DOWN | KEY_LEFT | KEY_RIGHT | KEY_A | KEY_B);
 
@@ -563,7 +573,7 @@ void inGameMenu(s8* mainScreen) {
 		drawCursor(cursorPosition);
 
 		#ifndef B4DS
-		waitKeysBattery(KEY_UP | KEY_DOWN | KEY_A | KEY_B);
+		waitKeysBattery(KEY_UP | KEY_DOWN | KEY_A | KEY_B | KEY_R);
 		#else
 		waitKeys(KEY_UP | KEY_DOWN | KEY_A | KEY_B);
 		#endif
@@ -612,6 +622,12 @@ void inGameMenu(s8* mainScreen) {
 				while (REG_VCOUNT == 191);
 			} while(KEYS & KEY_B);
 			sharedAddr[4] = 0x54495845; // EXIT
+		} else if (KEYS & KEY_R) {
+			do {
+				while (REG_VCOUNT != 191);
+				while (REG_VCOUNT == 191);
+			} while(KEYS & KEY_R);
+			sharedAddr[4] = 0x50455453; // STEP
 		}
 	}
 


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Adds stepping 1 frame by pressing <kbd>R</kbd> in the in-game menu (frame advances on button release)
- Does anyone else have other suggestions of a better way to do it? This was just my first idea
- Fixes #1220
- Also: Cleans up whitespace in ARM7 and adds RTL handling for screenshot submenu

In dual screen 3D areas you can actually get a full screenshot now:
![dual screen screenshot](https://user-images.githubusercontent.com/41608708/127652257-4d8f18b9-c496-4993-bf17-9495c4f55a51.png)


#### Where have you tested it?

- DSi (K) from Unlaunch

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
