### PR TITLE
Clear REG_BLDY_SUB for in-game menu

### DIFF
--- a/retail/cardenginei/arm9_igm/source/inGameMenu.c
+++ b/retail/cardenginei/arm9_igm/source/inGameMenu.c
@@ -542,6 +542,7 @@ void inGameMenu(s8* mainScreen) {
 	REG_POWERCNT |= POWER_SWAP_LCDS;
 
 	SetBrightness(1, 0);
+	REG_BLDY_SUB = 0; // Register is write only, can't back up
 
 	tonccpy(bgMapBak, BG_MAP_RAM_SUB(9), sizeof(bgMapBak));	// Backup BG_MAP_RAM
 	clearScreen();


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Fixes #1222 
- Unfortunately this register is write-only so there's no way to back it up which may cause graphical glitches, from my bit of testing it seems fine though (only affects layer blending brightness and games likely set it again quickly if fading or so)
- https://problemkaputt.de/gbatek-lcd-i-o-color-special-effects.htm

#### Where have you tested it?

- DSi (K) from Unlaunch

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
