### PR TITLE
Don't overwrite screenshots if blank one mid tar

### DIFF
--- a/retail/cardenginei/arm7/source/cardengine.c
+++ b/retail/cardenginei/arm7/source/cardengine.c
@@ -435,9 +435,14 @@ void saveScreenshot(void) {
 
 	driveInitialize();
 	sdRead = (valueBits & b_dsiSD);
-	fileWrite((char*)DONOR_ROM_ARM7_SIZE_LOCATION, screenshotFile, 0x200+(igmText->currentScreenshot*0x18400), 0x18046, !sdRead, -1);
+	fileWrite((char*)DONOR_ROM_ARM7_SIZE_LOCATION, screenshotFile, 0x200 + (igmText->currentScreenshot * 0x18400), 0x18046, !sdRead, -1);
 
-	igmText->currentScreenshot++;
+	// Skip until next blank slot
+	char magic;
+	do {
+		igmText->currentScreenshot++;
+		fileRead(&magic, screenshotFile, 0x200 + (igmText->currentScreenshot * 0x18400), 1, !sdRead, -1);
+	} while(magic == 'B' && igmText->currentScreenshot < 50);
 }
 
 static void log_arm9(void) {

--- a/retail/cardenginei/arm9_igm/source/inGameMenu.c
+++ b/retail/cardenginei/arm9_igm/source/inGameMenu.c
@@ -230,7 +230,7 @@ static void screenshot(void) {
 		} else if (KEYS & (KEY_DOWN | KEY_RIGHT)) {
 			if(vramBank < 3)
 				cursorPosition++;
-		} else if(KEYS & KEY_A) {
+		} else if(KEYS & KEY_A && igmText->currentScreenshot < 50) {
 			break;
 		} else if(KEYS & KEY_B) {
 			VRAM_x_CR(vramBank) = vramCr;


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- This makes it so that if there's a blank screenshot mid-tar it won't just overwrite all of the screenshots after it, instead it'll skip forward to the next blank slot, if any
- Also makes it so that pressing <kbd>A</kbd> in the screenshot menu does nothing when full (you have to press <kbd>B</kbd> to cancel)

#### Where have you tested it?

- DSi (K) from Unlaunch

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
