### PR TITLE
Only check VRAM banks A/B/C/D for mode B

### DIFF
--- a/retail/cardenginei/arm9_igm/source/inGameMenu.c
+++ b/retail/cardenginei/arm9_igm/source/inGameMenu.c
@@ -193,7 +193,7 @@ static void screenshot(void) {
 
 	// Use capture mode B if no banks are mapped for main engine
 	u8 captureMode = DCAP_MODE_B;
-	for(int i = 0; i < 7; i++) {
+	for(int i = 0; i < 4; i++) {
 		if(VRAM_x_CR(i) & 1)
 			captureMode = DCAP_MODE_A;
 	}


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- It seems Mega Max ZX doesn't bother to unmap bank F from main BG which was breaking the ActImagine detection, it's extremely unlikely that something would be on the main engine without using bank A/B/C/D so I think this check should still be enough to prevent any false positive matches
- Fixes Mega Man ZX ActImagine screenshots and while I haven't tested it likely fixes Infinite Space screenshots too

![Mega Man ZX screenshot](https://media.discordapp.net/attachments/283770736215195648/874931540986036224/screenshot31.bmp_.png)

#### Where have you tested it?

- DSi (K) from Unlaunch

***

#### Pull Request status
- [ ] This PR has been tested using the latest version of devkitARM and libnds.
