### PR TITLE
Fix freezing when taking screenshots in G5 Pokémon

### DIFF
--- a/retail/cardenginei/arm9_igm/source/inGameMenu.c
+++ b/retail/cardenginei/arm9_igm/source/inGameMenu.c
@@ -271,7 +271,10 @@ static void screenshot(void) {
 	VRAM_x_CR(vramBank) = vramCr;
 
 	sharedAddr[4] = 0x544F4853;
-	while (sharedAddr[4] == 0x544F4853);
+	while (sharedAddr[4] == 0x544F4853) {
+		while (REG_VCOUNT != 191);
+		while (REG_VCOUNT == 191);
+	}
 }
 
 static void drawCursor(u8 line) {

--- a/retail/cardenginei/arm9_igm/source/inGameMenu.c
+++ b/retail/cardenginei/arm9_igm/source/inGameMenu.c
@@ -537,7 +537,7 @@ void inGameMenu(s8* mainScreen) {
 	u16 masterBright = *(vu16*)0x0400106C;
 
 	REG_DISPCNT_SUB = 0x10100;
-	REG_BG0CNT_SUB = BG_MAP_BASE(15) | BG_TILE_BASE(0) | BgSize_T_256x256;
+	REG_BG0CNT_SUB = (u16)(BG_MAP_BASE(15) | BG_TILE_BASE(0) | BgSize_T_256x256);
 	//REG_BG1CNT_SUB = 0;
 	//REG_BG2CNT_SUB = 0;
 	//REG_BG3CNT_SUB = 0;
@@ -560,7 +560,7 @@ void inGameMenu(s8* mainScreen) {
 
 	tonccpy(palBak, BG_PALETTE_SUB, sizeof(palBak));	// Backup the palette
 	toncset16(BG_PALETTE_SUB, 0, 256);
-	for(int i = 0; i < sizeof(igmPal); i++) {
+	for(int i = 0; i < sizeof(igmPal) / sizeof(igmPal[0]); i++) {
 		BG_PALETTE_SUB[i * 0x10 + 1] = igmPal[i];
 	}
 


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Fixes freezing when taking screenshots in G5 Pokémon, it seems to have been because it was reading sharedAddr[4] to fast so this has it wait for vblanks
- Also fixes a couple warnings I missed

#### Where have you tested it?

- DSi (K) from Unlaunch

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
