### PR TITLE
Fix Battle & Get: Pokémon Typing DS

### DIFF
--- a/retail/arm9/include/configuration.h
+++ b/retail/arm9/include/configuration.h
@@ -57,7 +57,7 @@ typedef struct configuration {
 	bool saveOnFlashcard;
 	bool macroMode;
 	u16 hotkey;
-	bool irCard;
+	bool specialCard;
 } configuration;
 
 #endif // CONFIGURATION_H

--- a/retail/arm9/source/conf_sd.cpp
+++ b/retail/arm9/source/conf_sd.cpp
@@ -379,8 +379,8 @@ int loadFromSD(configuration* conf, const char *bootstrapPath) {
 			sysSetCardOwner(BUS_OWNER_ARM7);
 
 			// Leave Slot-1 enabled for IR cartridges and Battle & Get: Pokémon Typing DS
-			conf->irCard = (headerData[0xC] == 'I' || memcmp(headerData + 0xC, "UZP", 3) == 0);
-			if (!conf->irCard) {
+			conf->specialCard = (headerData[0xC] == 'I' || memcmp(headerData + 0xC, "UZP", 3) == 0);
+			if (!conf->specialCard) {
 				disableSlot1();
 			}
 		}

--- a/retail/arm9/source/conf_sd.cpp
+++ b/retail/arm9/source/conf_sd.cpp
@@ -358,7 +358,7 @@ int loadFromSD(configuration* conf, const char *bootstrapPath) {
 
   if (dsiFeatures()) {
 	if (!conf->gameOnFlashcard && !conf->saveOnFlashcard) {
-		if (romTid[0] != 'I') {
+		if (romTid[0] != 'I' && memcmp(romTid, "UZP", 3) != 0) {
 			disableSlot1();
 		} else {
 			enableSlot1();
@@ -378,7 +378,8 @@ int loadFromSD(configuration* conf, const char *bootstrapPath) {
 
 			sysSetCardOwner(BUS_OWNER_ARM7);
 
-			conf->irCard = (headerData[0xC] == 'I');
+			// Leave Slot-1 enabled for IR cartridges and Battle & Get: Pokémon Typing DS
+			conf->irCard = (headerData[0xC] == 'I' || memcmp(headerData + 0xC, "UZP", 3) == 0);
 			if (!conf->irCard) {
 				disableSlot1();
 			}

--- a/retail/arm9/source/nds_loader_arm9.c
+++ b/retail/arm9/source/nds_loader_arm9.c
@@ -295,7 +295,7 @@ int runNds(u32 cluster, u32 saveCluster, u32 donorE2Cluster, u32 donor2Cluster, 
 	loader->dmaRomRead_LED              = conf->dmaRomRead_LED;
 	loader->asyncCardRead               = conf->asyncCardRead;
 	loader->cardReadDMA                 = conf->cardReadDMA;
-	loader->irCard                      = conf->irCard;
+	loader->specialCard                      = conf->specialCard;
 
 	if (!dsiFeatures()) {
 		lc0 = (loadCrt0*)LOAD_CRT0_LOCATION_B4DS;

--- a/retail/bootloader/source/arm7/load_crt0.s
+++ b/retail/bootloader/source/arm7/load_crt0.s
@@ -68,7 +68,7 @@
 	.global asyncCardRead
 	.global cardReadDMA
 	.global soundFreq
-	.global irCard
+	.global specialCard
 @---------------------------------------------------------------------------------
 	.align	4
 	.arm
@@ -167,7 +167,7 @@ cardReadDMA:
 	.byte	0
 soundFreq:
 	.byte	0
-irCard:
+specialCard:
 	.byte	0
 .align 4
 

--- a/retail/bootloaderi/source/arm7/load_crt0.s
+++ b/retail/bootloaderi/source/arm7/load_crt0.s
@@ -68,7 +68,7 @@
 	.global asyncCardRead
 	.global cardReadDMA
 	.global soundFreq
-	.global irCard
+	.global specialCard
 @---------------------------------------------------------------------------------
 	.align	4
 	.arm
@@ -167,7 +167,7 @@ cardReadDMA:
 	.byte	0
 soundFreq:
 	.byte	0
-irCard:
+specialCard:
 	.byte	0
 .align 4
 

--- a/retail/bootloaderi/source/arm7/main.arm7.c
+++ b/retail/bootloaderi/source/arm7/main.arm7.c
@@ -118,7 +118,7 @@ extern u8 consoleModel;
 extern u8 romRead_LED;
 extern u8 dmaRomRead_LED;
 extern u8 soundFreq;
-extern u8 irCard;
+extern u8 specialCard;
 
 bool useTwlCfg = false;
 int twlCfgLang = 0;
@@ -1369,7 +1369,7 @@ int arm7_main(void) {
 		}*/
 
 		if (!gameOnFlashcard && REG_SCFG_EXT != 0 && !(REG_SCFG_MC & BIT(0))) {
-			if (irCard) {
+			if (specialCard) {
 				// Enable Slot-1 for games that use IR
 				my_enableSlot1();
 			} else {

--- a/retail/common/include/load_crt0.h
+++ b/retail/common/include/load_crt0.h
@@ -52,7 +52,7 @@ typedef struct loadCrt0 {
     u8 asyncCardRead;
     u8 cardReadDMA;
     u8 soundFreq;
-    u8 irCard;
+    u8 specialCard;
 } __attribute__ ((__packed__)) loadCrt0;
 
 #endif // LOAD_CRT0_H


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Enables Slot-1 for Battle & Get: Pokémon Typing DS too so that it can work

#### Where have you tested it?

- DSi (K) from Unlaunch with Japanese cartridge and Nintendo Wireless Keyboard with Japanese and European ROMs
   - When using a Japanese keyboard with a European ROM (or vise versa presumably) the layout is wrong, so you need to type from memory instead of the labels, but otherwise works fine
   - ~~You also seem to need to re-pair the keyboard when switching ROMs (saves?)~~ nvm, worked second time, I guess I was impatient

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
