### PR TITLE
Fix DSi mode in-game menu being slow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,7 @@ build/
 #!.vscode/tasks.json
 #!.vscode/launch.json
 #!.vscode/extensions.json
+hb/nitrofiles/sdengine.bin
 retail/nitrofiles/cardengine_arm7*.bin
 retail/nitrofiles/cardengine_arm9*.bin
 retail/nitrofiles/cardenginei_arm7*.bin

--- a/retail/cardenginei/arm7/source/inGameMenu.c
+++ b/retail/cardenginei/arm7/source/inGameMenu.c
@@ -33,8 +33,8 @@ void inGameMenu(void) {
 
 	int timeOut = 0;
 	while (sharedAddr[5] != 0x59444552) { // 'REDY'
-		while (REG_VCOUNT != 191);
-		while (REG_VCOUNT == 191);
+		while (REG_VCOUNT != 191) swiDelay(1000);
+		while (REG_VCOUNT == 191) swiDelay(1000);
 
 		timeOut++;
 		if (timeOut == 60*2) {
@@ -53,8 +53,8 @@ void inGameMenu(void) {
 				timeTilBatteryLevelRefresh = 0;
 			}
 
-			while (REG_VCOUNT != 191);
-			while (REG_VCOUNT == 191);
+			while (REG_VCOUNT != 191) swiDelay(1000);
+			while (REG_VCOUNT == 191) swiDelay(1000);
 
 			switch (sharedAddr[4]) {
 				case 0x54495845: // EXIT


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- It seems that in DSi mode when both the ARM7 and ARM9 are constantly checking REG_VCOUNT it causes a lot of slowdown, so this adds a swiDelay(1000) to all of the VCOUNT loops on ARM7
   - I'm not sure if 1,000 is a good number, that was chosen completely arbitrarily because I have no idea what's best
   - Not sure if it'd be good to do this on ARM9 too, or if that doesn't matter, I chose ARM7 as it has less of them
- Also adds hb/nitrofiles/sdengine.bin to the .gitignore

#### Where have you tested it?

- DSi (K) from Unlaunch using Pokémon Black 2 (DSi Mode) and Pokémon Heart Gold (DS Mode)

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
