### PR TITLE
Fix Flipnote Studio screenshots being blank

### DIFF
--- a/retail/cardenginei/arm9_igm/source/inGameMenu.c
+++ b/retail/cardenginei/arm9_igm/source/inGameMenu.c
@@ -111,7 +111,7 @@ static void printHex(int x, int y, u32 val, u8 bytes, int palette) {
 #ifndef B4DS
 static void printBattery(void) {
 	u8 batteryLevel = (u8)sharedAddr[6];
-	const unsigned char *bars = "\3\3";
+	const char *bars = "\3\3";
 	if (batteryLevel & BIT(7)) {
 		bars = "\6\6";	// Charging
 	} else {
@@ -133,7 +133,7 @@ static void printBattery(void) {
 				break;
 		}
 	}
-	print(0x20 - 4, 0x18 - 2, bars, 3);
+	print(0x20 - 4, 0x18 - 2, (const unsigned char *)bars, 3);
 }
 #endif
 
@@ -190,7 +190,7 @@ static void screenshot(void) {
 
 	// Use capture mode B if no banks are mapped for main engine
 	u8 captureMode = DCAP_MODE_B;
-	for(int i = 0; i < 6; i++) {
+	for(int i = 0; i <= 6; i++) {
 		if(VRAM_x_CR(i) & 1)
 			captureMode = DCAP_MODE_A;
 	}

--- a/retail/cardenginei/arm9_igm/source/inGameMenu.c
+++ b/retail/cardenginei/arm9_igm/source/inGameMenu.c
@@ -190,7 +190,7 @@ static void screenshot(void) {
 
 	// Use capture mode B if no banks are mapped for main engine
 	u8 captureMode = DCAP_MODE_B;
-	for(int i = 0; i < 4; i++) {
+	for(int i = 0; i < 6; i++) {
 		if(VRAM_x_CR(i) & 1)
 			captureMode = DCAP_MODE_A;
 	}


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- It was only checking the main 4 banks for if something was mapped to main engine, but the first 3 secondary banks can be used too and guess what, Flipnote does
   ![screenshot06](https://user-images.githubusercontent.com/41608708/148899920-ecfa760b-c01a-4ec0-a547-88d615058d7c.png)
- Also fixes some warnings on the battery strings

#### Where have you tested it?

- DSi (K) from Unlaunch

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
