### PR TITLE
nds-bootstrap version files stay with nds-bootstrap

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,8 +53,7 @@ jobs:
       - name: Pack 7z nightly
         if: ${{ !startsWith(github.ref, 'refs/tags') }}
         run: |
-          mkdir bin/TWiLightMenu/
-          printf "${{ steps.vars.outputs.commit_hash }}\n" >> bin/TWiLightMenu/nightly-bootstrap.ver
+          printf "${{ steps.vars.outputs.commit_hash }}\n" >> bin/nightly-bootstrap.ver
           mv bin/ nds-bootstrap/
           7z a nds-bootstrap.7z nds-bootstrap/
 


### PR DESCRIPTION
This the small part needed in conjunction with the changes on TWiLightMenu so the nds-bootstrap .ver files stay together with the .nds files

Closes #1383 