### PR TITLE
Mini refactor, move globals into local static scope

### DIFF
--- a/retail/cardenginei/arm7/source/cardengine.c
+++ b/retail/cardenginei/arm7/source/cardengine.c
@@ -697,8 +697,9 @@ void saveScreenshot(void) {
 #endif
 }
 
-int currentManualLine = 0, currentManualOffset = 0;
 void readManual(int line) {
+	static int currentManualLine = 0;
+	static int currentManualOffset = 0;
 	sdRead = (valueBits & b_dsiSD);
 	char buffer[32];
 

--- a/retail/cardenginei/arm7_dsiware/source/cardengine.c
+++ b/retail/cardenginei/arm7_dsiware/source/cardengine.c
@@ -526,8 +526,9 @@ void saveScreenshot(void) {
 	fileRead((char*)INGAME_MENU_EXT_LOCATION, pageFile, 0x540000, 0x40000, !sdRead, -1);
 }
 
-int currentManualLine = 0, currentManualOffset = 0;
 void readManual(int line) {
+	static int currentManualLine = 0;
+	static int currentManualOffset = 0;
 	driveInitialize();
 	char buffer[32];
 


### PR DESCRIPTION

#### What's changed?

No functional code change.

Moved globals used for reading manuals from disk into local scope as static so as to preserve values. Related to https://github.com/DS-Homebrew/nds-bootstrap/pull/1392 by @Epicpkmn11

#### Where have you tested it?

💣 100% untested! I don't have my kit with me :-(

***

#### Pull Request status
- [ ] This PR has been tested using the latest version of devkitARM and libnds.
