### PR TITLE
Add brightness and volume to in-game menu

### DIFF
--- a/retail/arm9/source/conf_sd.cpp
+++ b/retail/arm9/source/conf_sd.cpp
@@ -287,16 +287,18 @@ void getIgmStrings(configuration* conf, bool b4ds) {
 	setIgmString(lang.fetch("MENU", "RAM_VIEWER", "RAM Viewer...").c_str(), igmText->menu[6]);
 	setIgmString(lang.fetch("MENU", "QUIT_GAME", "Quit Game").c_str(), igmText->menu[7]);
 
-	setIgmString(lang.fetch("OPTIONS", "MAIN_SCREEN", "Main Screen").c_str(), igmText->options[0]);
-	setIgmString(lang.fetch("OPTIONS", "CLOCK_SPEED", "Clock Speed").c_str(), igmText->options[1]);
-	setIgmString(lang.fetch("OPTIONS", "VRAM_MODE", "VRAM Mode").c_str(), igmText->options[2]);
-	setIgmString(lang.fetch("OPTIONS", "AUTO", "Auto").c_str(), igmText->options[3]);
-	setIgmString(lang.fetch("OPTIONS", "BOTTOM", "Bottom").c_str(), igmText->options[4]);
-	setIgmString(lang.fetch("OPTIONS", "TOP", "Top").c_str(), igmText->options[5]);
-	setIgmString(lang.fetch("OPTIONS", "67_MHZ", "67 MHz").c_str(), igmText->options[6]);
-	setIgmString(lang.fetch("OPTIONS", "133_MHZ", "133 MHz").c_str(), igmText->options[7]);
-	setIgmString(lang.fetch("OPTIONS", "DS_MODE", "DS mode").c_str(), igmText->options[8]);
-	setIgmString(lang.fetch("OPTIONS", "DSI_MODE", "DSi mode").c_str(), igmText->options[9]);
+	setIgmString(lang.fetch("OPTIONS", "MAIN_SCREEN", "Main Screen").c_str(), igmText->optionsLabels[0]);
+	setIgmString(lang.fetch("OPTIONS", "BRIGHTNESS", "Brightness").c_str(), igmText->optionsLabels[1]);
+	setIgmString(lang.fetch("OPTIONS", "VOLUME", "Volume").c_str(), igmText->optionsLabels[2]);
+	setIgmString(lang.fetch("OPTIONS", "CLOCK_SPEED", "Clock Speed").c_str(), igmText->optionsLabels[3]);
+	setIgmString(lang.fetch("OPTIONS", "VRAM_MODE", "VRAM Mode").c_str(), igmText->optionsLabels[4]);
+	setIgmString(lang.fetch("OPTIONS", "AUTO", "Auto").c_str(), igmText->optionsValues[0]);
+	setIgmString(lang.fetch("OPTIONS", "BOTTOM", "Bottom").c_str(), igmText->optionsValues[1]);
+	setIgmString(lang.fetch("OPTIONS", "TOP", "Top").c_str(), igmText->optionsValues[2]);
+	setIgmString(lang.fetch("OPTIONS", "67_MHZ", "67 MHz").c_str(), igmText->optionsValues[3]);
+	setIgmString(lang.fetch("OPTIONS", "133_MHZ", "133 MHz").c_str(), igmText->optionsValues[4]);
+	setIgmString(lang.fetch("OPTIONS", "DS_MODE", "DS mode").c_str(), igmText->optionsValues[5]);
+	setIgmString(lang.fetch("OPTIONS", "DSI_MODE", "DSi mode").c_str(), igmText->optionsValues[6]);
 
 	// Get manual line count if there's a manual
 	FILE *manualFile = fopen(conf->manualPath, "r");

--- a/retail/cardengine/arm9/source/cardengine.c
+++ b/retail/cardengine/arm9/source/cardengine.c
@@ -306,8 +306,8 @@ void myIrqHandlerIPC(void) {
 			fileRead((char*)INGAME_MENU_LOCATION_B4DS, pageFile, 0, 0xA000);	// Read in-game menu
 
 			*(u32*)(INGAME_MENU_LOCATION_B4DS + IGM_TEXT_SIZE_ALIGNED) = (u32)sharedAddr;
-			volatile void (*inGameMenu)(s8*) = (volatile void*)INGAME_MENU_LOCATION_B4DS + IGM_TEXT_SIZE_ALIGNED + 0x10;
-			(*inGameMenu)(&mainScreen);
+			volatile void (*inGameMenu)(s8*, u32) = (volatile void*)INGAME_MENU_LOCATION_B4DS + IGM_TEXT_SIZE_ALIGNED + 0x10;
+			(*inGameMenu)(&mainScreen, 0);
 
 			fileWrite((char*)INGAME_MENU_LOCATION_B4DS, pageFile, 0, 0xA000);	// Store in-game menu
 			fileRead((char*)INGAME_MENU_LOCATION_B4DS, pageFile, 0xA000, 0xA000);	// Restore part of game RAM from page file

--- a/retail/cardenginei/arm7/source/inGameMenu.thumb.c
+++ b/retail/cardenginei/arm7/source/inGameMenu.thumb.c
@@ -26,7 +26,7 @@ extern void prepareScreenshot(void);
 extern void saveScreenshot(void);
 extern void readManual(int line);
 
-volatile int timeTilBatteryLevelRefresh = 7;
+volatile int timeTillStatusRefresh = 7;
 
 void inGameMenu(void) {
 	returnToMenu = false;
@@ -52,10 +52,20 @@ void inGameMenu(void) {
 		while (!exitMenu) {
 			sharedAddr[5] = ~REG_KEYINPUT & 0x3FF;
 			sharedAddr[5] |= ((~REG_EXTKEYINPUT & 0x3) << 10) | ((~REG_EXTKEYINPUT & 0xC0) << 6);
-			timeTilBatteryLevelRefresh++;
-			if (timeTilBatteryLevelRefresh >= 8) {
-				sharedAddr[6] = i2cReadRegister(I2C_PM, I2CREGPM_BATTERY);
-				timeTilBatteryLevelRefresh = 0;
+			timeTillStatusRefresh++;
+			if (timeTillStatusRefresh >= 8) {
+				timeTillStatusRefresh = 0;
+
+				u8 brightness = i2cReadRegister(I2C_PM, 0x41);
+				u32 pmControl = readPowerManagement(PM_CONTROL_REG);
+				if(brightness && !(pmControl & 0xC)) { // Turn on backlights if SELECT+volume used
+					pmControl |= 0xC;
+					writePowerManagement(PM_CONTROL_REG, pmControl);
+				}
+
+				sharedAddr[6] = i2cReadRegister(I2C_PM, I2CREGPM_BATTERY); // Battery
+				sharedAddr[6] |= (brightness + ((pmControl & 0xC) != 0)) << 8; // Brightness
+				sharedAddr[6] |= i2cReadRegister(I2C_PM, I2CREGPM_VOL) << 16; // Volume
 			}
 
 			while (REG_VCOUNT != 191) swiDelay(100);
@@ -67,7 +77,7 @@ void inGameMenu(void) {
 					break;
 				case 0x54455352: // RSET
 					exitMenu = true;
-					timeTilBatteryLevelRefresh = 7;
+					timeTillStatusRefresh = 7;
 					#ifdef TWLSDK
 					i2cWriteRegister(0x4A, 0x12, 0x01);
 					#endif
@@ -108,6 +118,19 @@ void inGameMenu(void) {
 				case 0x574D4152: // RAMW
 					tonccpy((u8*)((u32)sharedAddr[1])+sharedAddr[2], (u8*)((u32)sharedAddr[0])+sharedAddr[2], 1);
 					break;
+				case 0x4554494C: // LITE
+					if(sharedAddr[0] == 0) {
+						writePowerManagement(PM_CONTROL_REG, readPowerManagement(PM_CONTROL_REG) & ~0xC);
+					} else {
+						i2cWriteRegister(I2C_PM, 0x41, sharedAddr[0] - 1);
+						writePowerManagement(PM_CONTROL_REG, readPowerManagement(PM_CONTROL_REG) | 0xC);
+					}
+					timeTillStatusRefresh = 7;
+					break;
+				case 0x554C4F56: // VOLU
+					i2cWriteRegister(I2C_PM, I2CREGPM_VOL, sharedAddr[0]);
+					timeTillStatusRefresh = 7;
+					break;
 				default:
 					break;
 			}
@@ -119,7 +142,7 @@ void inGameMenu(void) {
 	}
 
 	sharedAddr[4] = 0x54495845; // EXIT
-	timeTilBatteryLevelRefresh = 7;
+	timeTillStatusRefresh = 7;
 
 	leaveCriticalSection(oldIME);
 	REG_MASTER_VOLUME = 127;

--- a/retail/cardenginei/arm9/source/cardengine.c
+++ b/retail/cardenginei/arm9/source/cardengine.c
@@ -710,8 +710,8 @@ void myIrqHandlerIPC(void) {
 			break;
 		case 0x9: {
 			*(u32*)(INGAME_MENU_LOCATION + IGM_TEXT_SIZE_ALIGNED) = (u32)sharedAddr;
-			volatile void (*inGameMenu)(s8*) = (volatile void*)INGAME_MENU_LOCATION + IGM_TEXT_SIZE_ALIGNED + 0x10;
-			(*inGameMenu)(&mainScreen);
+			volatile void (*inGameMenu)(s8*, u32) = (volatile void*)INGAME_MENU_LOCATION + IGM_TEXT_SIZE_ALIGNED + 0x10;
+			(*inGameMenu)(&mainScreen, ce9->consoleModel);
 			if (sharedAddr[3] == 0x52534554) {
 				igmReset = true;
 				reset(0);

--- a/retail/cardenginei/arm9_dsiware/source/cardengine.c
+++ b/retail/cardenginei/arm9_dsiware/source/cardengine.c
@@ -258,8 +258,8 @@ void myIrqHandlerIPC(void) {
 			break;
 		case 0x9: {
 			*(u32*)(INGAME_MENU_LOCATION_DSIWARE + IGM_TEXT_SIZE_ALIGNED) = (u32)sharedAddr;
-			volatile void (*inGameMenu)(s8*) = (volatile void*)INGAME_MENU_LOCATION_DSIWARE + IGM_TEXT_SIZE_ALIGNED + 0x10;
-			(*inGameMenu)(&mainScreen);
+			volatile void (*inGameMenu)(s8*, u32) = (volatile void*)INGAME_MENU_LOCATION_DSIWARE + IGM_TEXT_SIZE_ALIGNED + 0x10;
+			(*inGameMenu)(&mainScreen, ce9->consoleModel);
 			if (sharedAddr[3] == 0x52534554 || sharedAddr[3] == 0x54495845) {
 				igmReset = true;
 				if (sharedAddr[3] == 0x52534554) {

--- a/retail/cardenginei/arm9_igm/source/card_engine_header.s
+++ b/retail/cardenginei/arm9_igm/source/card_engine_header.s
@@ -17,7 +17,7 @@
 
 #Text is placed here
 igmText:
-.space 0x9E4
+.space 0xA0C
 .align 4
 
 sharedAddr:

--- a/retail/cardenginei/arm9_romInRam/source/cardengine.c
+++ b/retail/cardenginei/arm9_romInRam/source/cardengine.c
@@ -590,12 +590,12 @@ void myIrqHandlerIPC(void) {
 			if (!(ce9->valueBits & extendedMemory)) {
 				if (ndsHeader->unitCode > 0 && (ce9->valueBits & dsiMode)) {
 					*(u32*)(INGAME_MENU_LOCATION_TWLSDK + IGM_TEXT_SIZE_ALIGNED) = (u32)sharedAddr;
-					volatile void (*inGameMenu)(s8*) = (volatile void*)INGAME_MENU_LOCATION_TWLSDK + IGM_TEXT_SIZE_ALIGNED + 0x10;
-					(*inGameMenu)(&mainScreen);
+					volatile void (*inGameMenu)(s8*, u32) = (volatile void*)INGAME_MENU_LOCATION_TWLSDK + IGM_TEXT_SIZE_ALIGNED + 0x10;
+					(*inGameMenu)(&mainScreen, ce9->consoleModel);
 				} else {
 					*(u32*)(INGAME_MENU_LOCATION + IGM_TEXT_SIZE_ALIGNED) = (u32)sharedAddr;
-					volatile void (*inGameMenu)(s8*) = (volatile void*)INGAME_MENU_LOCATION + IGM_TEXT_SIZE_ALIGNED + 0x10;
-					(*inGameMenu)(&mainScreen);
+					volatile void (*inGameMenu)(s8*, u32) = (volatile void*)INGAME_MENU_LOCATION + IGM_TEXT_SIZE_ALIGNED + 0x10;
+					(*inGameMenu)(&mainScreen, ce9->consoleModel);
 				}
 				if (sharedAddr[3] == 0x52534554) {
 					igmReset = true;

--- a/retail/cardenginei/arm9_sdk5/source/cardengine.c
+++ b/retail/cardenginei/arm9_sdk5/source/cardengine.c
@@ -848,12 +848,12 @@ void myIrqHandlerIPC(void) {
 		case 0x9: {
 #ifdef TWLSDK
 			*(u32*)(INGAME_MENU_LOCATION_TWLSDK + IGM_TEXT_SIZE_ALIGNED) = (u32)sharedAddr;
-			volatile void (*inGameMenu)(s8*) = (volatile void*)INGAME_MENU_LOCATION_TWLSDK + IGM_TEXT_SIZE_ALIGNED + 0x10;
+			volatile void (*inGameMenu)(s8*, u32) = (volatile void*)INGAME_MENU_LOCATION_TWLSDK + IGM_TEXT_SIZE_ALIGNED + 0x10;
 #else
 			*(u32*)(INGAME_MENU_LOCATION + IGM_TEXT_SIZE_ALIGNED) = (u32)sharedAddr;
-			volatile void (*inGameMenu)(s8*) = (volatile void*)INGAME_MENU_LOCATION + IGM_TEXT_SIZE_ALIGNED + 0x10;
+			volatile void (*inGameMenu)(s8*, u32) = (volatile void*)INGAME_MENU_LOCATION + IGM_TEXT_SIZE_ALIGNED + 0x10;
 #endif
-			(*inGameMenu)(&mainScreen);
+			(*inGameMenu)(&mainScreen, ce9->consoleModel);
 			if (sharedAddr[3] == 0x52534554) {
 				igmReset = true;
 #ifdef TWLSDK

--- a/retail/common/include/igm_text.h
+++ b/retail/common/include/igm_text.h
@@ -13,7 +13,8 @@ struct IgmText {
 	unsigned char selectBank[20];
 	unsigned char count[14];
 	unsigned char menu[8][20];
-	unsigned char options[10][20];
+	unsigned char optionsLabels[5][20];
+	unsigned char optionsValues[7][20];
 
 	u8 font[256 * 8];
 
@@ -25,7 +26,7 @@ struct IgmText {
 };
 
 #ifdef __cplusplus
-static_assert(sizeof(IgmText) == 0x9E4, "IgmText is too big! Allocate more space in the in-game menu header");
+static_assert(sizeof(IgmText) == 0xA0C, "IgmText is too big! Allocate more space in the in-game menu header");
 
 enum class IgmFont : u8 {
 	arabic = 0,

--- a/retail/nitrofiles/languages/en/in_game_menu.ini
+++ b/retail/nitrofiles/languages/en/in_game_menu.ini
@@ -16,6 +16,8 @@ QUIT_GAME=Quit Game
 
 [OPTIONS]
 MAIN_SCREEN=Main Screen
+BRIGHTNESS=Brightness
+VOLUME=Volume
 CLOCK_SPEED=Clock Speed
 VRAM_MODE=VRAM Mode
 


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Adds brightness and volume to the in-game menu options menu
- Only DSi has both, 3DS only has volume and DS (Lite) only have brightness
   - On 3DS the volume is reset as soon as you touch the slider
- UNTESTED on DS (Lite) as for some reason I can't get nds-bootstrap to work on any of my flashcards, even the release but it should theoretically work

#### Where have you tested it?

- DSi (K) from Unlaunch
- n3DS (U)

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
