### PR TITLE
Derp fix: Fix DS Lite detection & more

### DIFF
--- a/retail/cardengine/arm7/source/inGameMenu.thumb.c
+++ b/retail/cardengine/arm7/source/inGameMenu.thumb.c
@@ -46,10 +46,10 @@ void inGameMenu(void) {
 			timeTillStatusRefresh++;
 			if (timeTillStatusRefresh >= 8) {
 				u32 pmBacklight = readPowerManagement(PM_BACKLIGHT_LEVEL);
-				if((pmBacklight & 0xF0) == 0xF0) { // DS Lite
+				if(pmBacklight & 0xF0) { // DS Lite
 					sharedAddr[6] = ((pmBacklight & 3) + ((readPowerManagement(PM_CONTROL_REG) & 0xC) != 0)) << 8; // Brightness
 				} else { // DS Phat
-					sharedAddr[6] = ((readPowerManagement(PM_CONTROL_REG) & 0xC) != 0) ? 5 : 0;
+					sharedAddr[6] = (((readPowerManagement(PM_CONTROL_REG) & 0xC) != 0) ? 5 : 0) << 8;
 				}
 				timeTillStatusRefresh = 0;
 			}
@@ -82,8 +82,8 @@ void inGameMenu(void) {
 						writePowerManagement(PM_CONTROL_REG, readPowerManagement(PM_CONTROL_REG) & ~0xC);
 					} else {
 						u32 pmBacklight = readPowerManagement(PM_BACKLIGHT_LEVEL);
-						if((pmBacklight & 0xF0) == 0xF0) // DS Lite
-							writePowerManagement(PM_BACKLIGHT_LEVEL, pmBacklight | (sharedAddr[0] - 1));
+						if(pmBacklight & 0xF0) // DS Lite
+							writePowerManagement(PM_BACKLIGHT_LEVEL, (pmBacklight & ~3) | (sharedAddr[0] - 1));
 						writePowerManagement(PM_CONTROL_REG, readPowerManagement(PM_CONTROL_REG) | 0xC);
 					}
 					timeTillStatusRefresh = 7;

--- a/retail/cardenginei/arm9_igm/source/inGameMenu.c
+++ b/retail/cardenginei/arm9_igm/source/inGameMenu.c
@@ -14,6 +14,12 @@
 void DC_InvalidateRange(const void *base, u32 size);
 void DC_FlushRange(const void *base, u32 size);
 
+#ifndef B4DS
+	#define MAX_BRIGHTNESS 5
+#else
+	#define MAX_BRIGHTNESS 4
+#endif
+
 typedef enum {
 	MENU_EXIT = 0,
 	MENU_RESET = 1,
@@ -381,7 +387,7 @@ static void optionsMenu(s8 *mainScreen, u32 consoleModel) {
 					optionValue = igmText.optionsValues[*mainScreen];
 					break;
 				case OPTIONS_BRIGHTNESS:
-					optionPercent = (u8)(sharedAddr[6] >> 8) * 100 / 5;
+					optionPercent = (u8)(sharedAddr[6] >> 8) * 100 / MAX_BRIGHTNESS;
 					isString = false;
 					break;
 				case OPTIONS_VOLUME:
@@ -444,7 +450,7 @@ static void optionsMenu(s8 *mainScreen, u32 consoleModel) {
 					u8 brightness = (u8)(sharedAddr[6] >> 8);
 					if(KEYS & KEY_LEFT && brightness > 0)
 						brightness--;
-					else if (KEYS & KEY_RIGHT && brightness < 5)
+					else if (KEYS & KEY_RIGHT && brightness < MAX_BRIGHTNESS)
 						brightness++;
 
 					sharedAddr[0] = brightness;


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Fixes DS Lites being detected as DS Phats
   - I misread what TWiLight was doing and GBATEK was saying, I think it's actually `0x40` but this matches what TWiLight checks
- Also fixes writing brightness level to the battery part of the status on DS Phat (thus making it ignored and always show 0%)
- And changes to having 4 brightness levels on DS Lite, not 5, I didn't notice that was different from DSi

#### Where have you tested it?

- @RocketRobz on DS Lite

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
