### PR TITLE
Fix Japanese font mapping

### DIFF
--- a/retail/arm9/source/text.cpp
+++ b/retail/arm9/source/text.cpp
@@ -64,9 +64,9 @@ constexpr char16_t mapHebrew[] =
 constexpr char16_t mapJapanese[] =
 	u"‥…　いぅかさどなにぬのむるをん"
 	u"アクゲシジスセダットドバビプムモ"
-	u"ャュョリレロン　　　　　　　　　"
-	u"ー上下主了動定度戻択数明書画終自"
-	u"設説速選量面音";
+	u"ャュョリレロンー　　　　　　　　"
+	u"上下主了動定度戻択数明書画終自設"
+	u"説速選量面音";
 
 constexpr char16_t mapChinese[] =
 	u"主书亮位儲出到动動区器回图圖地址"


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Fixes the in-game menu Japanese font mapping being incorrect
   - I don't usually test the translation updates since there's not much that can go wrong, I usually test when updating the fonts but I forgot to last time and turns out I missed one of the last changes I made to the image, thus resulting in nonsense like `ゲ上ムを自動` (Auto the ge-up-mu) (instead of `ゲームを終了` (Quit game))
- I think fixes #1452

#### Where have you tested it?

- DSi (K) from Unlaunch (in Japanese)

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
