### PR TITLE
Fix a ton of warnings

### DIFF
--- a/hb/bootloaderInject/source/boot.c
+++ b/hb/bootloaderInject/source/boot.c
@@ -325,7 +325,7 @@ void mpu_reset_end();*/
 int main (void) {
 	//nocashMessage("bootloader");
 
-	extern char _io_dldi;
+	extern void *_io_dldi;
 	//const char* bootName = "BOOT.NDS";
 
 	if(memcmp(_io_dldi, "RAMD", 4) == 0)

--- a/retail/arm9/include/twltool/dsi.h
+++ b/retail/arm9/include/twltool/dsi.h
@@ -38,7 +38,7 @@ void		dsi_set_ctr( dsi_context* ctx,
 
 void		dsi_init_ctr( dsi_context* ctx, 
 						  const unsigned char key[16], 
-						  const unsigned char ctr[12] );
+						  const unsigned char ctr[16] );
 
 void dsi_crypt_ctr( dsi_context* ctx,
                     const void* in,

--- a/retail/arm9/source/nand/nandio.c
+++ b/retail/arm9/source/nand/nandio.c
@@ -33,7 +33,7 @@ void getConsoleID(u8 *consoleID){
 	
 	tonccpy(key, fifo, 16);  //receive the goods from arm7
 
-	F_XY_reverse((uint32_t*)key, (uint32_t*)key_xy); //work backwards from the normalkey to get key_x that has the consoleID
+	F_XY_reverse(key, key_xy); //work backwards from the normalkey to get key_x that has the consoleID
 
 	for(int i=0;i<16;i++){
 		key_x[i] = key_xy[i] ^ key_y[i];             //''

--- a/retail/arm9/source/nand/sector0.c
+++ b/retail/arm9/source/nand/sector0.c
@@ -28,28 +28,30 @@ int parse_ncsd(const uint8_t sector0[SECTOR_SIZE], int verbose) {
 		if (fs_type == 0) {
 			break;
 		}
-		const char *s_fs_type;
-		switch (fs_type) {
-			case 1:
-				s_fs_type = "Normal";
-				break;
-			case 3:
-				s_fs_type = "FIRM";
-				break;
-			case 4:
-				s_fs_type = "AGB_FIRM save";
-				break;
-			default:
-				if (verbose) {
-					//iprintf("invalid partition type %d\n", fs_type);
-				}
-				return -2;
-		}
 		if (verbose) {
+			/*
+			const char *s_fs_type;
+			switch (fs_type) {
+				case 1:
+					s_fs_type = "Normal";
+					break;
+				case 3:
+					s_fs_type = "FIRM";
+					break;
+				case 4:
+					s_fs_type = "AGB_FIRM save";
+					break;
+				default:
+					if (verbose) {
+						//iprintf("invalid partition type %d\n", fs_type);
+					}
+					return -2;
+			}
 			// yes I use MB for "MiB", bite me
-			//iprintf("partition %u, %s, crypt: %" PRIu8 ", offset: 0x%08" PRIx32 ", length: 0x%08" PRIx32 "(%s MB)\n",
-				//i, s_fs_type, h->crypt_types[i],
-				//h->partitions[i].offset, h->partitions[i].length, to_mebi(h->partitions[i].length * SECTOR_SIZE));
+			iprintf("partition %u, %s, crypt: %" PRIu8 ", offset: 0x%08" PRIx32 ", length: 0x%08" PRIx32 "(%s MB)\n",
+				i, s_fs_type, h->crypt_types[i],
+				h->partitions[i].offset, h->partitions[i].length, to_mebi(h->partitions[i].length * SECTOR_SIZE));
+			*/
 		}
 	}
 	return 0;

--- a/retail/arm9/source/twltool/dsi.c
+++ b/retail/arm9/source/twltool/dsi.c
@@ -58,7 +58,7 @@ void dsi_set_ctr( dsi_context* ctx,
 
 void dsi_init_ctr( dsi_context* ctx,
 				   const unsigned char key[16],
-				   const unsigned char ctr[12] )
+				   const unsigned char ctr[16] )
 {
 	dsi_set_key(ctx, key);
 	dsi_set_ctr(ctx, ctr);

--- a/retail/bootloader/source/arm7/decompress.c
+++ b/retail/bootloader/source/arm7/decompress.c
@@ -22,7 +22,7 @@
 #include "locations.h"
 #include "tonccpy.h"
 
-static const unsigned char* encr_data = (unsigned char*)BLOWFISH_LOCATION_B4DS;
+static unsigned char* encr_data = (unsigned char*)BLOWFISH_LOCATION_B4DS;
 
 /*static void decompressLZ77Backwards(u8* addr, u32 size) {
 	u32 len = *(u32*)(addr + size - 4) + size;

--- a/retail/bootloader/source/arm7/find_arm9.c
+++ b/retail/bootloader/source/arm7/find_arm9.c
@@ -84,7 +84,7 @@ static const u16 cardReadDmaStartSignatureThumb3[1]  = {0xB5F8}; // SDK >= 3
 
 // Random patch
 static const u32 randomPatchSignature[4]        = {0xE3500000, 0x1597002C, 0x10406004, 0x03E06000};
-static const u32 randomPatchSignature5First[4]  = {0xE92D43F8, 0xE3A04000, 0xE1A09001, 0xE1A08002}; // SDK 5
+// static const u32 randomPatchSignature5First[4]  = {0xE92D43F8, 0xE3A04000, 0xE1A09001, 0xE1A08002}; // SDK 5
 static const u32 randomPatchSignature5Second[3] = {0xE59F003C, 0xE590001C, 0xE3500000};             // SDK 5
 
 // irq enable
@@ -248,7 +248,7 @@ u32* findCardReadEndOffsetType0(const tNDSHeader* ndsHeader, const module_params
 u32* findCardReadEndOffsetType1(const tNDSHeader* ndsHeader, u32 startOffset) {
 	dbg_printf("findCardReadEndOffsetType1:\n");
 
-	const char* romTid = getRomTid(ndsHeader);
+	// const char* romTid = getRomTid(ndsHeader);
 
 	u32* cardReadEndOffset = NULL;
 	//readType = 1;
@@ -1574,7 +1574,7 @@ u32* findRandomPatchOffset5Second(const tNDSHeader* ndsHeader) {
 
 u32* findResetOffset(const tNDSHeader* ndsHeader, const module_params_t* moduleParams, bool* softResetMb) {
 	dbg_printf("findResetOffset\n");
-    u32* resetSignature = resetSignature2;
+    const u32* resetSignature = resetSignature2;
 
     if (moduleParams->sdk_version > 0x4008000 && moduleParams->sdk_version < 0x5000000) { 
         resetSignature = resetSignature4;
@@ -1690,7 +1690,7 @@ u32* findResetOffset(const tNDSHeader* ndsHeader, const module_params_t* moduleP
     } 
     
     while(resetOffset!=NULL) {
-    	u32* resetEndOffset = findOffsetThumb(
+    	u32* resetEndOffset = findOffset(
     		resetOffset, 0x200,
     		(isSdk5(moduleParams) ? resetConstant5 : resetConstant), 1
     	);

--- a/retail/bootloader/source/arm7/hook_arm9.c
+++ b/retail/bootloader/source/arm7/hook_arm9.c
@@ -1,10 +1,14 @@
 #include <stdio.h>
+#include <string.h>
 #include <nds/ndstypes.h>
 #include <nds/debug.h>
 #include "patch.h"
+#include "find.h"
 #include "hook.h"
 #include "common.h"
 #include "cardengine_header_arm9.h"
+#include "debug_file.h"
+#include "nds_header.h"
 
 #define b_expansionPakFound BIT(0)
 #define b_extendedMemory BIT(1)

--- a/retail/bootloader/source/arm7/patch_common.c
+++ b/retail/bootloader/source/arm7/patch_common.c
@@ -43,7 +43,7 @@ static inline void doubleNopT(u32 addr) {
 }
 
 void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
-	extern u32 _io_dldi_features;
+	// extern u32 _io_dldi_features;
 	extern bool expansionPakFound;
 	extern u32 donorFileTwlCluster;	// SDK5 (TWL)
 	extern u32 fatTableAddr;
@@ -78,7 +78,7 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 	// Requires 8MB of RAM
 	if (strcmp(romTid, "DMEE") == 0 && extendedMemory2) {
 
-		//*(u32*)0x02004B9C = 0x0200002F;
+		// *(u32*)0x02004B9C = 0x0200002F;
 		*(u32*)0x02008DD8 = 0xE1A00000; // nop
 		*(u32*)0x02008EF4 = 0xE1A00000; // nop
 		*(u32*)0x02008F08 = 0xE1A00000; // nop
@@ -99,7 +99,7 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 	// Requires 8MB of RAM
 	else if (strcmp(romTid, "DMDE") == 0 && extendedMemory2) {
 
-		//*(u32*)0x02004B9C = 0x0200002F;
+		// *(u32*)0x02004B9C = 0x0200002F;
 		*(u32*)0x02008E04 = 0xE1A00000; // nop
 		*(u32*)0x02008F14 = 0xE1A00000; // nop
 		*(u32*)0x02008F28 = 0xE1A00000; // nop
@@ -130,7 +130,7 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 	// Requires 8MB of RAM
 	else if ((strcmp(romTid, "DHSE") == 0 || strcmp(romTid, "DHSV") == 0) && extendedMemory2) {
 
-		//*(u32*)0x02004B9C = 0x0200002F;
+		// *(u32*)0x02004B9C = 0x0200002F;
 		*(u32*)0x02005108 = 0xE1A00000; // nop
 		*(u32*)0x0200517C = 0xE1A00000; // nop
 		*(u32*)0x02005190 = 0xE1A00000; // nop
@@ -213,7 +213,7 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		*(u32*)0x02039CDC = 0xE1A00000; // nop
 		*(u32*)0x02039E3C = 0xE1A00000; // nop
 		patchHiHeapDSiWare(0x02039E98, heapEnd); // mov r0, #0x23E0000
-		//*(u32*)0x02039FCC = 0x02115860;
+		// *(u32*)0x02039FCC = 0x02115860;
 		patchUserSettingsReadDSiWare(0x0203B3CC);
 		*(u32*)0x0203B7D4 = 0xE1A00000; // nop
 		*(u32*)0x0203B7D8 = 0xE1A00000; // nop
@@ -275,7 +275,7 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		*(u32*)0x0200E40C = 0xE12FFF1E; // bx lr
 		*(u32*)0x0200E54C = 0xE3A00001; // mov r0, #1
 		*(u32*)0x0200E550 = 0xE12FFF1E; // bx lr */
-		//*(u32*)0x0200E010 = 0xE3A00001; // mov r0, #1 (dsiSaveFreeSpaceAvailable)
+		// *(u32*)0x0200E010 = 0xE3A00001; // mov r0, #1 (dsiSaveFreeSpaceAvailable)
 		setBL(0x0200E0D4, (u32)dsiSaveCreate);
 		setBL(0x0200E0E4, (u32)dsiSaveOpen);
 		setBL(0x0200E11C, (u32)dsiSaveSetLength);
@@ -325,7 +325,7 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		*(u32*)0x0200E3BC = 0xE12FFF1E; // bx lr
 		*(u32*)0x0200E4FC = 0xE3A00001; // mov r0, #1
 		*(u32*)0x0200E500 = 0xE12FFF1E; // bx lr */
-		//*(u32*)0x0200DFC0 = 0xE3A00001; // mov r0, #1 (dsiSaveFreeSpaceAvailable)
+		// *(u32*)0x0200DFC0 = 0xE3A00001; // mov r0, #1 (dsiSaveFreeSpaceAvailable)
 		setBL(0x0200E084, (u32)dsiSaveCreate);
 		setBL(0x0200E094, (u32)dsiSaveOpen);
 		setBL(0x0200E0CC, (u32)dsiSaveSetLength);
@@ -1466,10 +1466,10 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		*(u32*)0x020050B4 = 0xE1A00000; // nop
 		*(u32*)0x020050C4 = 0xE1A00000; // nop
 		*(u32*)0x020051B8 = 0xE1A00000; // nop
-		//*(u32*)0x0203BB4C = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x0203BB50 = 0xE12FFF1E; // bx lr
-		//*(u32*)0x0203BC18 = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x0203BC1C = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0203BB4C = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x0203BB50 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0203BC18 = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x0203BC1C = 0xE12FFF1E; // bx lr
 		setBL(0x0203BBE4, (u32)dsiSaveOpen);
 		setBL(0x0203BC08, (u32)dsiSaveClose);
 		*(u32*)0x0203BC2C = 0xE1A00000; // nop
@@ -1523,10 +1523,10 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		*(u32*)0x020050B4 = 0xE1A00000; // nop
 		*(u32*)0x020050C4 = 0xE1A00000; // nop
 		*(u32*)0x020051B8 = 0xE1A00000; // nop
-		//*(u32*)0x0203BC5C = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x0203BC60 = 0xE12FFF1E; // bx lr
-		//*(u32*)0x0203BD28 = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x0203BD2C = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0203BC5C = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x0203BC60 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0203BD28 = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x0203BD2C = 0xE12FFF1E; // bx lr
 		setBL(0x0203BCF4, (u32)dsiSaveOpen);
 		setBL(0x0203BD18, (u32)dsiSaveClose);
 		*(u32*)0x0203BD3C = 0xE1A00000; // nop
@@ -1567,10 +1567,10 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		*(u32*)0x020050B8 = 0xE1A00000; // nop
 		*(u32*)0x020050C4 = 0xE1A00000; // nop
 		*(u32*)0x020051B8 = 0xE1A00000; // nop
-		//*(u32*)0x0203E250 = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x0203E254 = 0xE12FFF1E; // bx lr
-		//*(u32*)0x0203E324 = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x0203E328 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0203E250 = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x0203E254 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0203E324 = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x0203E328 = 0xE12FFF1E; // bx lr
 		setBL(0x0203E2F0, (u32)dsiSaveOpen);
 		setBL(0x0203E314, (u32)dsiSaveClose);
 		*(u32*)0x0203E334 = 0xE1A00000; // nop
@@ -1607,7 +1607,7 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 
 		*(u32*)0x020050A4 = 0xE1A00000; // nop (Disable NFTR loading from TWLNAND)
 		*(u32*)0x020050A8 = 0xE1A00000; // nop
-		//*(u32*)0x0200DC9C = 0xE1A00000; // nop
+		// *(u32*)0x0200DC9C = 0xE1A00000; // nop
 		*(u32*)0x02059E0C = 0xE1A00000; // nop
 		*(u32*)0x02059E14 = 0xE1A00000; // nop
 		setBL(0x02059E20, (u32)dsiSaveCreate);
@@ -1642,7 +1642,7 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 
 		*(u32*)0x020050A4 = 0xE1A00000; // nop (Disable NFTR loading from TWLNAND)
 		*(u32*)0x020050A8 = 0xE1A00000; // nop
-		//*(u32*)0x0200DD70 = 0xE1A00000; // nop
+		// *(u32*)0x0200DD70 = 0xE1A00000; // nop
 		*(u32*)0x02059EE0 = 0xE1A00000; // nop
 		*(u32*)0x02059EE8 = 0xE1A00000; // nop
 		setBL(0x02059EF4, (u32)dsiSaveCreate);
@@ -1677,7 +1677,7 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 
 		*(u32*)0x020050A4 = 0xE1A00000; // nop (Disable NFTR loading from TWLNAND)
 		*(u32*)0x020050A8 = 0xE1A00000; // nop
-		//*(u32*)0x0200DD70 = 0xE1A00000; // nop
+		// *(u32*)0x0200DD70 = 0xE1A00000; // nop
 		*(u32*)0x02059DF0 = 0xE1A00000; // nop
 		*(u32*)0x02059DF8 = 0xE1A00000; // nop
 		setBL(0x02059E04, (u32)dsiSaveCreate);
@@ -1807,14 +1807,14 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		setBL(0x020267D4, (u32)dsiSaveOpen);
 		setBL(0x020267E8, (u32)dsiSaveCreate);
 		setBL(0x02026814, (u32)dsiSaveOpen);
-		//*(u32*)0x02026834 = 0xE3A01B0B; // mov r1, #0x2C00
+		// *(u32*)0x02026834 = 0xE3A01B0B; // mov r1, #0x2C00
 		setBL(0x0202683C, (u32)dsiSaveSetLength);
 		setBL(0x0202684C, (u32)dsiSaveClose);
 		setBL(0x02026870, (u32)dsiSaveWrite);
 		setBL(0x0202687C, (u32)dsiSaveGetLength);
 		*(u32*)0x02026880 = 0xE1A02000; // mov r2, r0
 		*(u32*)0x02026884 = 0xE3A01000; // mov r1, #0
-		//*(u32*)0x02026888 = 0xE3A03000; // mov r3, #0
+		// *(u32*)0x02026888 = 0xE3A03000; // mov r3, #0
 		setBL(0x020268B8, (u32)dsiSaveSeek);
 		setBL(0x020268D4, (u32)dsiSaveRead);
 		setBL(0x02026BDC, (u32)dsiSaveSeek);
@@ -1894,10 +1894,10 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		setBL(0x02092E94, (u32)dsiSaveClose);
 
 		// Skip Manual screen (Not working)
-		//*(u32*)0x02092FDC = 0xE1A00000; // nop (Disable NFTR loading from TWLNAND)
-		//*(u32*)0x02093070 = 0xE1A00000; // nop
-		//*(u32*)0x02093078 = 0xE1A00000; // nop
-		//*(u32*)0x02093084 = 0xE1A00000; // nop
+		// *(u32*)0x02092FDC = 0xE1A00000; // nop (Disable NFTR loading from TWLNAND)
+		// *(u32*)0x02093070 = 0xE1A00000; // nop
+		// *(u32*)0x02093078 = 0xE1A00000; // nop
+		// *(u32*)0x02093084 = 0xE1A00000; // nop
 	}
 
 	// Bejeweled Twist (USA)
@@ -2200,9 +2200,9 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		*(u32*)0x0201B8BC = 0xE3A00003; // mov r0, #3
 		if (ndsHeader->gameCode[3] == 'E') {
 			*(u32*)0x0204351C = 0xE1A00000; // nop
-			//*(u32*)0x02043528 = 0xE3A00000; // mov r0, #0 (Skip WiFi error screen)
-			//*(u32*)0x020437AC = 0xE3A00001; // mov r0, #1
-			//*(u32*)0x020437B0 = 0xE12FFF1E; // bx lr
+			// *(u32*)0x02043528 = 0xE3A00000; // mov r0, #0 (Skip WiFi error screen)
+			// *(u32*)0x020437AC = 0xE3A00001; // mov r0, #1
+			// *(u32*)0x020437B0 = 0xE12FFF1E; // bx lr
 			*(u32*)0x020437B4 = 0xE1A00000; // nop
 			*(u32*)0x020437D0 = 0xE1A00000; // nop
 			*(u32*)0x020437D8 = 0xE1A00000; // nop
@@ -2270,9 +2270,9 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 			*(u32*)0x020AB024 = 0xE2841B01; // add r1, r4, #0x400
 		} else if (ndsHeader->gameCode[3] == 'V') {
 			*(u32*)0x020435E8 = 0xE1A00000; // nop
-			//*(u32*)0x020435F4 = 0xE3A00000; // mov r0, #0 (Skip WiFi error screen)
-			//*(u32*)0x02043878 = 0xE3A00001; // mov r0, #1
-			//*(u32*)0x0204387C = 0xE12FFF1E; // bx lr
+			// *(u32*)0x020435F4 = 0xE3A00000; // mov r0, #0 (Skip WiFi error screen)
+			// *(u32*)0x02043878 = 0xE3A00001; // mov r0, #1
+			// *(u32*)0x0204387C = 0xE12FFF1E; // bx lr
 			*(u32*)0x02043880 = 0xE1A00000; // nop
 			*(u32*)0x0204389C = 0xE1A00000; // nop
 			*(u32*)0x020438A4 = 0xE1A00000; // nop
@@ -2340,9 +2340,9 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 			*(u32*)0x020AB120 = 0xE2841B01; // add r1, r4, #0x400
 		} else if (ndsHeader->gameCode[3] == 'J') {
 			*(u32*)0x02043248 = 0xE1A00000; // nop
-			//*(u32*)0x02043254 = 0xE3A00000; // mov r0, #0 (Skip WiFi error screen)
-			//*(u32*)0x020434D8 = 0xE3A00001; // mov r0, #1
-			//*(u32*)0x020434DC = 0xE12FFF1E; // bx lr
+			// *(u32*)0x02043254 = 0xE3A00000; // mov r0, #0 (Skip WiFi error screen)
+			// *(u32*)0x020434D8 = 0xE3A00001; // mov r0, #1
+			// *(u32*)0x020434DC = 0xE12FFF1E; // bx lr
 			*(u32*)0x020434E0 = 0xE1A00000; // nop
 			*(u32*)0x020434FC = 0xE1A00000; // nop
 			*(u32*)0x02043504 = 0xE1A00000; // nop
@@ -2452,13 +2452,13 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 	else if (strcmp(romTid, "KAHE") == 0) {
 		*(u32*)0x0202FBD0 = 0xE1A00000; // nop
 		setBL(0x020353B4, (u32)dsiSaveOpen);
-		//*(u32*)0x020355D8 = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x020355DC = 0xE12FFF1E; // bx lr
+		// *(u32*)0x020355D8 = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x020355DC = 0xE12FFF1E; // bx lr
 		setBL(0x02035608, (u32)dsiSaveOpen);
 		setBL(0x02035658, (u32)dsiSaveRead);
 		setBL(0x0203569C, (u32)dsiSaveClose);
-		//*(u32*)0x020356C4 = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x020356C8 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x020356C4 = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x020356C8 = 0xE12FFF1E; // bx lr
 		setBL(0x020356E8, (u32)dsiSaveCreate);
 		setBL(0x020356F8, (u32)dsiSaveGetResultCode);
 		setBL(0x0203571C, (u32)dsiSaveOpen);
@@ -2490,13 +2490,13 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 	else if (strcmp(romTid, "KAHV") == 0) {
 		*(u32*)0x0202FB18 = 0xE1A00000; // nop
 		setBL(0x02034FFC, (u32)dsiSaveOpen);
-		//*(u32*)0x02035220 = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x02035224 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x02035220 = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x02035224 = 0xE12FFF1E; // bx lr
 		setBL(0x02035250, (u32)dsiSaveOpen);
 		setBL(0x020352A0, (u32)dsiSaveRead);
 		setBL(0x020352E4, (u32)dsiSaveClose);
-		//*(u32*)0x0203530C = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x02035310 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0203530C = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x02035310 = 0xE12FFF1E; // bx lr
 		setBL(0x02035330, (u32)dsiSaveCreate);
 		setBL(0x02035340, (u32)dsiSaveGetResultCode);
 		setBL(0x02035364, (u32)dsiSaveOpen);
@@ -2528,13 +2528,13 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 	else if (strcmp(romTid, "KAHJ") == 0) {
 		*(u32*)0x0202F148 = 0xE1A00000; // nop
 		setBL(0x02034348, (u32)dsiSaveOpen);
-		//*(u32*)0x0203456C = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x02034570 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0203456C = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x02034570 = 0xE12FFF1E; // bx lr
 		setBL(0x0203459C, (u32)dsiSaveOpen);
 		setBL(0x020345EC, (u32)dsiSaveRead);
 		setBL(0x02034630, (u32)dsiSaveClose);
-		//*(u32*)0x02034658 = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x0203465C = 0xE12FFF1E; // bx lr
+		// *(u32*)0x02034658 = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x0203465C = 0xE12FFF1E; // bx lr
 		setBL(0x0203467C, (u32)dsiSaveCreate);
 		setBL(0x0203468C, (u32)dsiSaveGetResultCode);
 		setBL(0x020346B0, (u32)dsiSaveOpen);
@@ -3051,9 +3051,9 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		if (!extendedMemory2) {
 			*(u32*)0x0203D44C = 0x2C00C8; // Shrink sound heap from 0x3000C8
 		}
-		//*(u32*)0x0204AFD8 = 0xE12FFF1E; // bx lr
-		//*(u32*)0x0204B084 = 0xE12FFF1E; // bx lr
-		//*(u32*)0x0204B44C = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0204AFD8 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0204B084 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0204B44C = 0xE12FFF1E; // bx lr
 		setBL(0x0204AFF4, (u32)dsiSaveCreate);
 		setBL(0x0204B014, (u32)dsiSaveOpen);
 		*(u32*)0x0204B034 = 0xE1A00000; // nop
@@ -3100,11 +3100,11 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 			if (!extendedMemory2) {
 				*(u32*)0x0202B3F8 = 0x2C00D0; // Shrink sound heap from 0x3000D0
 			}
-			//*(u32*)0x0203A5A4 = 0xE12FFF1E; // bx lr
-			//*(u32*)0x0203A7D4 = 0xE12FFF1E; // bx lr
-			//*(u32*)0x0203AB6C = 0xE12FFF1E; // bx lr
-			//*(u32*)0x0203B134 = 0xE12FFF1E; // bx lr
-			//*(u32*)0x0203BA14 = 0xE12FFF1E; // bx lr
+			// *(u32*)0x0203A5A4 = 0xE12FFF1E; // bx lr
+			// *(u32*)0x0203A7D4 = 0xE12FFF1E; // bx lr
+			// *(u32*)0x0203AB6C = 0xE12FFF1E; // bx lr
+			// *(u32*)0x0203B134 = 0xE12FFF1E; // bx lr
+			// *(u32*)0x0203BA14 = 0xE12FFF1E; // bx lr
 			setBL(0x0203A75C, (u32)dsiSaveOpen);
 			setBL(0x0203A78C, (u32)dsiSaveWrite);
 			setBL(0x0203A7AC, (u32)dsiSaveSeek);
@@ -4002,8 +4002,8 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		*(u16*)0x020851A4 = 0x46C0; // nop
 		*(u16*)0x020851A6 = 0x46C0; // nop
 		*(u32*)0x020891BC = 0xE1A00000; // nop
-		//*(u32*)0x0208AE4C = 0xE12FFF1E; // bx lr
-		//*(u32*)0x0208B008 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0208AE4C = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0208B008 = 0xE12FFF1E; // bx lr
 		*(u32*)0x0208AE6C = 0xE1A00000; // nop
 		setBL(0x0208AE90, (u32)dsiSaveOpen);
 		setBL(0x0208AEA4, (u32)dsiSaveCreate);
@@ -4188,10 +4188,10 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		*(u32*)0x020248C4 = 0xE12FFF1E; // bx lr (Skip NFTR font rendering)
 		*(u32*)0x02025CD4 = 0xE12FFF1E; // bx lr (Skip NFTR font rendering)
 		*(u32*)0x0203D228 = 0xE3A00000; // mov r0, #0 (Skip saving to "back.dat")
-		//*(u32*)0x0203D488 = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x0203D48C = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0203D488 = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x0203D48C = 0xE12FFF1E; // bx lr
 		if (ndsHeader->gameCode[3] == 'E') {
-			//*(u32*)0x02044B00 = 0xE3A00000; // mov r0, #0
+			// *(u32*)0x02044B00 = 0xE3A00000; // mov r0, #0
 			setBL(0x020590C0, (u32)dsiSaveCreate);
 			setBL(0x02059270, (u32)dsiSaveOpen);
 			setBL(0x020593CC, (u32)dsiSaveClose);
@@ -4208,7 +4208,7 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 			*(u32*)0x0207401C = 0xE3A00000; // mov r0, #0
 			*(u32*)0x02074054 = 0xE1A00000; // nop (Skip NFTR file loading from TWLNAND)
 		} else {
-			//*(u32*)0x02044A9C = 0xE3A00000; // mov r0, #0
+			// *(u32*)0x02044A9C = 0xE3A00000; // mov r0, #0
 			setBL(0x02058FB0, (u32)dsiSaveCreate);
 			setBL(0x02059160, (u32)dsiSaveOpen);
 			setBL(0x020592BC, (u32)dsiSaveClose);
@@ -4254,9 +4254,9 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		*(u32*)0x0202DFB8 = 0xE3A00000; // mov r0, #0
 		*(u32*)0x0202DFF0 = 0xE1A00000; // nop (Skip NFTR file loading from TWLNAND)
 		*(u32*)0x0205824C = 0xE3A00000; // mov r0, #0 (Skip saving to "back.dat")
-		//*(u32*)0x020584B4 = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x020584B8 = 0xE12FFF1E; // bx lr
-		//*(u32*)0x0205F6F0 = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x020584B4 = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x020584B8 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0205F6F0 = 0xE3A00000; // mov r0, #0
 		setBL(0x020736C4, (u32)dsiSaveCreate);
 		setBL(0x02073874, (u32)dsiSaveOpen);
 		setBL(0x020739D0, (u32)dsiSaveClose);
@@ -4272,11 +4272,11 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 	// Dragon's Lair (USA)
 	else if (strcmp(romTid, "KDLE") == 0) {
 
-		//*(u32*)0x02004B9C = 0x0200002F;
+		// *(u32*)0x02004B9C = 0x0200002F;
 		*(u32*)0x020050CC = 0xE1A00000; // nop
 		*(u32*)0x020051E4 = 0xE1A00000; // nop (Skip Manual screen)
-		//*(u32*)0x02012064 = 0xE1A00000; // nop
-		//*(u32*)0x02012068 = 0xE1A00000; // nop
+		// *(u32*)0x02012064 = 0xE1A00000; // nop
+		// *(u32*)0x02012068 = 0xE1A00000; // nop
 		/*for (int i = 0; i < 5; i++) {
 			u32* offset1 = (u32*)0x020132C0;
 			u32* offset2 = (u32*)0x020135FC;
@@ -4327,11 +4327,11 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 	// Dragon's Lair (Europe, Australia)
 	else if (strcmp(romTid, "KDLV") == 0) {
 
-		//*(u32*)0x02004B9C = 0x0200002F;
+		// *(u32*)0x02004B9C = 0x0200002F;
 		*(u32*)0x020050CC = 0xE1A00000; // nop
 		*(u32*)0x020051E4 = 0xE1A00000; // nop (Skip Manual screen)
-		//*(u32*)0x0201205C = 0xE1A00000; // nop
-		//*(u32*)0x02012060 = 0xE1A00000; // nop
+		// *(u32*)0x0201205C = 0xE1A00000; // nop
+		// *(u32*)0x02012060 = 0xE1A00000; // nop
 		/*for (int i = 0; i < 5; i++) {
 			u32* offset1 = (u32*)0x020132B4;
 			u32* offset2 = (u32*)0x020135F0;
@@ -4384,8 +4384,8 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 
 		*(u32*)0x020050D4 = 0xE1A00000; // nop
 		*(u32*)0x020051C8 = 0xE1A00000; // nop (Skip Manual screen)
-		//*(u32*)0x020171CC = 0xE1A00000; // nop
-		//*(u32*)0x020171D0 = 0xE1A00000; // nop
+		// *(u32*)0x020171CC = 0xE1A00000; // nop
+		// *(u32*)0x020171D0 = 0xE1A00000; // nop
 		*(u32*)0x0201FFEC = 0xE1A00000; // nop
 		setBL(0x02020034, (u32)dsiSaveOpen);
 		setBL(0x0202004C, (u32)dsiSaveRead);
@@ -4430,8 +4430,8 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 
 		*(u32*)0x020050EC = 0xE1A00000; // nop
 		*(u32*)0x020051E0 = 0xE1A00000; // nop (Skip Manual screen)
-		//*(u32*)0x020171E8 = 0xE1A00000; // nop
-		//*(u32*)0x020171EC = 0xE1A00000; // nop
+		// *(u32*)0x020171E8 = 0xE1A00000; // nop
+		// *(u32*)0x020171EC = 0xE1A00000; // nop
 		*(u32*)0x02020004 = 0xE1A00000; // nop
 		setBL(0x0202004C, (u32)dsiSaveOpen);
 		setBL(0x02020064, (u32)dsiSaveRead);
@@ -4488,7 +4488,7 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		*(u32*)0x020B66DC = 0xE1A00000; // nop
 		*(u32*)0x020B6820 = 0xE1A00000; // nop
 		patchHiHeapDSiWare(0x020B687C, 0x02700000); // mov r0, #0x2700000
-		//*(u32*)0x020B69B0 = 0x022A83C0;
+		// *(u32*)0x020B69B0 = 0x022A83C0;
 		patchUserSettingsReadDSiWare(0x020B7BF0);
 		*(u32*)0x020B7C18 = 0xE3A00001; // mov r0, #1
 		*(u32*)0x020B7C1C = 0xE12FFF1E; // bx lr
@@ -4617,9 +4617,9 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 
 		*(u32*)0x02005234 = 0xE1A00000; // nop
 		*(u32*)0x02005530 = 0xE1A00000; // nop
-		//*(u32*)0x02005534 = 0xE1A00000; // nop
+		// *(u32*)0x02005534 = 0xE1A00000; // nop
 		*(u32*)0x0200A3D8 = 0xE1A00000; // nop (Disable NFTR loading from TWLNAND)
-		//*(u32*)0x0200A898 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0200A898 = 0xE12FFF1E; // bx lr
 		setBL(0x0200AC14, (u32)dsiSaveOpen);
 		setBL(0x0200AC50, (u32)dsiSaveRead);
 		setBL(0x0200AC70, (u32)dsiSaveClose);
@@ -5599,10 +5599,10 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		doubleNopT(0x02028230); // dsiSaveFlush
 		setBLThumb(0x02028236, dsiSaveCloseT); */
 		doubleNopT(0x0203633E);
-		//*(u16*)0x0203728C = 0x2000; // movs r0, #0 (dsiSaveOpenDir)
-		//*(u16*)0x0203728E = 0x4770; // bx lr
-		//*(u16*)0x020372D8 = 0x2000; // movs r0, #0 (dsiSaveCloseDir)
-		//*(u16*)0x020372DA = 0x4770; // bx lr
+		// *(u16*)0x0203728C = 0x2000; // movs r0, #0 (dsiSaveOpenDir)
+		// *(u16*)0x0203728E = 0x4770; // bx lr
+		// *(u16*)0x020372D8 = 0x2000; // movs r0, #0 (dsiSaveCloseDir)
+		// *(u16*)0x020372DA = 0x4770; // bx lr
 		doubleNopT(0x02038386);
 		doubleNopT(0x0203AC10);
 		doubleNopT(0x0203C232);
@@ -6013,7 +6013,7 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 	// Glory Days: Tactical Defense (Europe)
 	else if (strcmp(romTid, "KGKE") == 0 || strcmp(romTid, "KGKP") == 0) {
 
-		//*(u32*)0x02004B9C = 0x0200002F;
+		// *(u32*)0x02004B9C = 0x0200002F;
 		*(u32*)0x0200B488 = 0xE1A00000; // nop
 		*(u32*)0x02017128 = 0xE1A00000; // nop
 		*(u32*)0x02018F94 = 0xE1A00000; // nop
@@ -6079,7 +6079,7 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		*(u32*)0x0201C024 = 0xE1A00000; // nop
 		*(u32*)0x0201C184 = 0xE1A00000; // nop
 		patchHiHeapDSiWare(0x0201C1E0, 0x02700000); // mov r0, #0x2700000
-		//*(u32*)0x0201C314 -= 0x30000;
+		// *(u32*)0x0201C314 -= 0x30000;
 		patchUserSettingsReadDSiWare(0x0201D604);
 		*(u32*)0x02021190 = 0xE1A00000; // nop
 		*(u32*)0x02022AD8 = 0xE1A00000; // nop
@@ -6181,7 +6181,7 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		*(u32*)0x0201C054 = 0xE1A00000; // nop
 		*(u32*)0x0201C1B4 = 0xE1A00000; // nop
 		patchHiHeapDSiWare(0x0201C210, 0x02700000); // mov r0, #0x2700000
-		//*(u32*)0x0201C344 -= 0x30000;
+		// *(u32*)0x0201C344 -= 0x30000;
 		patchUserSettingsReadDSiWare(0x0201D634);
 		*(u32*)0x020211C0 = 0xE1A00000; // nop
 		*(u32*)0x02022B08 = 0xE1A00000; // nop
@@ -7380,7 +7380,7 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		*(u32*)0x02060820 = 0xE1A00000; // nop
 		*(u32*)0x02060980 = 0xE1A00000; // nop
 		patchHiHeapDSiWare(0x020609DC, /*extendedMemory2 ?*/ 0x02700000 /*: heapEnd*/); // mov r0, extendedMemory2 ? #0x2700000 : #0x23E0000
-		//*(u32*)0x02060B10 -= extendedMemory2 ? 0x100000 : 0x310000;
+		// *(u32*)0x02060B10 -= extendedMemory2 ? 0x100000 : 0x310000;
 		patchUserSettingsReadDSiWare(0x02061F74);
 		*(u32*)0x0206237C = 0xE1A00000; // nop
 		*(u32*)0x02062380 = 0xE1A00000; // nop
@@ -7449,7 +7449,7 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		doubleNopT(0x0203C5EA);
 		doubleNopT(0x0203C6D6);
 		patchHiHeapDSiWareThumb(0x0203C714, 0x02039A40, 0x02700000);
-		//*(u32*)0x0203C7EC = 0x02090140;
+		// *(u32*)0x0203C7EC = 0x02090140;
 		*(u16*)0x020474DA = 0x46C0; // nop
 		*(u16*)0x020474E6 = 0x46C0; // nop
 		*(u16*)0x020474F0 = 0x46C0; // nop
@@ -7546,10 +7546,10 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		*(u32*)0x0204D7C4 = 0xE3A00000; // mov r0, #0
 		*(u32*)0x0204D7E4 = 0xE3A00000; // mov r0, #0
 		*(u32*)0x0204D800 = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x0204DF68 = 0xE3A00001; // mov r0, #1
-		//*(u32*)0x0204DF6C = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0204DF68 = 0xE3A00001; // mov r0, #1
+		// *(u32*)0x0204DF6C = 0xE12FFF1E; // bx lr
 		*(u32*)0x02051724 = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x020552DC = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x020552DC = 0xE3A00000; // mov r0, #0
 		*(u32*)0x02055B94 = 0xE3A00000; // mov r0, #0
 		//tonccpy((u32*)0x02057F8C, dsiSaveGetResultCode, 0xC);
 		*(u32*)0x0205A830 = 0xE3A00000; // mov r0, #0
@@ -8019,10 +8019,10 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		setBL(0x020B1B34, (u32)dsiSaveClose);
 
 		// Skip Manual screen (Not working)
-		//*(u32*)0x020B2800 = 0xE1A00000; // nop (Disable NFTR loading from TWLNAND)
-		//*(u32*)0x020B2894 = 0xE1A00000; // nop
-		//*(u32*)0x020B289C = 0xE1A00000; // nop
-		//*(u32*)0x020B28A8 = 0xE1A00000; // nop
+		// *(u32*)0x020B2800 = 0xE1A00000; // nop (Disable NFTR loading from TWLNAND)
+		// *(u32*)0x020B2894 = 0xE1A00000; // nop
+		// *(u32*)0x020B289C = 0xE1A00000; // nop
+		// *(u32*)0x020B28A8 = 0xE1A00000; // nop
 	}
 
 	// Monster Buster Club (USA)
@@ -8038,7 +8038,7 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		*(u32*)0x0207F640 = 0xE12FFF1E; // bx lr */
 		*(u32*)0x0207F098 = 0xE1A00000; // nop
 		*(u32*)0x0207F0B8 = 0xE3A00001; // mov r0, #1
-		//*(u32*)0x0207F17C = 0xE3A00001; // mov r0, #1 (dsiSaveFreeSpaceAvailable)
+		// *(u32*)0x0207F17C = 0xE3A00001; // mov r0, #1 (dsiSaveFreeSpaceAvailable)
 		*(u32*)0x0207F224 = 0xE1A00000; // nop
 		setBL(0x0207F244, (u32)dsiSaveCreate);
 		setBL(0x0207F254, (u32)dsiSaveOpen);
@@ -8085,7 +8085,7 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		*(u32*)0x0207F55C = 0xE12FFF1E; // bx lr */
 		*(u32*)0x0207EFA4 = 0xE1A00000; // nop
 		*(u32*)0x0207EFC4 = 0xE3A00001; // mov r0, #1
-		//*(u32*)0x0207F084 = 0xE3A00001; // mov r0, #1 (dsiSaveFreeSpaceAvailable)
+		// *(u32*)0x0207F084 = 0xE3A00001; // mov r0, #1 (dsiSaveFreeSpaceAvailable)
 		*(u32*)0x0207F12C = 0xE1A00000; // nop
 		setBL(0x0207F14C, (u32)dsiSaveCreate);
 		setBL(0x0207F15C, (u32)dsiSaveOpen);
@@ -8749,12 +8749,12 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		*(u32*)0x0202B070 = 0xE1A00000; // nop
 		*(u32*)0x0202B078 = 0xE1A00000; // nop
 		*(u32*)0x0202B080 = 0xE1A00000; // nop
-		//*(u32*)0x02036694 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x02036694 = 0xE12FFF1E; // bx lr
 		*(u32*)0x020366AC = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x020366C4 = 0xE3A00001; // mov r0, #1
-		//*(u32*)0x020366E4 = 0xE3A00001; // mov r0, #1
-		//*(u32*)0x02036708 = 0xE3A00001; // mov r0, #1
-		//*(u32*)0x02036738 = 0xE3A00001; // mov r0, #1
+		// *(u32*)0x020366C4 = 0xE3A00001; // mov r0, #1
+		// *(u32*)0x020366E4 = 0xE3A00001; // mov r0, #1
+		// *(u32*)0x02036708 = 0xE3A00001; // mov r0, #1
+		// *(u32*)0x02036738 = 0xE3A00001; // mov r0, #1
 		*(u32*)0x02036C94 = 0xE1A00000; // nop
 		*(u32*)0x0205D920 = 0xE1A00000; // nop
 	}*/
@@ -8857,7 +8857,7 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		patchHiHeapDSiWare(0x02019E80, heapEnd); // mov r0, #0x23E0000
 		patchUserSettingsReadDSiWare(0x0201B104);
 		*(u32*)0x0201E40C = 0xE1A00000; // nop
-		//*(u32*)0x0203A20C = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0203A20C = 0xE12FFF1E; // bx lr
 		setBL(0x02048524, (u32)dsiSaveOpen);
 		setBL(0x0204853C, (u32)dsiSaveCreate);
 		setBL(0x02048554, (u32)dsiSaveOpen);
@@ -8912,7 +8912,7 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		setBL(0x0202F08C, (u32)dsiSaveCreate); // dsiSaveCreateAuto
 		setBL(0x0202F09C, (u32)dsiSaveOpen);
 		setBL(0x0202F0C8, (u32)dsiSaveClose);
-		//*(u32*)0x0203A730 = 0xE3A00001; // mov r0, #1
+		// *(u32*)0x0203A730 = 0xE3A00001; // mov r0, #1
 	}
 
 	// Peg Solitaire (USA)
@@ -9163,7 +9163,7 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		*(u32*)0x0202DB38 = 0xE1A00000; // nop
 		*(u32*)0x0202DB3C = 0xE1A00000; // nop
 		patchHiHeapDSiWare(0x0202DB98, 0x02700000); // mov r0, #0x2700000
-		//*(u32*)0x0202DCCC = 0x0218B0A0;
+		// *(u32*)0x0202DCCC = 0x0218B0A0;
 		patchUserSettingsReadDSiWare(0x0202EE48);
 		*(u32*)0x0202EE70 = 0xE3A00001; // mov r0, #1
 		*(u32*)0x0202EE74 = 0xE12FFF1E; // bx lr
@@ -9180,8 +9180,8 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		*(u32*)0x020050E4 = 0xE1A00000; // nop
 		*(u32*)0x020052A4 = 0xE1A00000; // nop
 		*(u32*)0x0200A5C4 = 0xE1A00000; // nop
-		//*(u32*)0x0200A66C = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x0200A670 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0200A66C = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x0200A670 = 0xE12FFF1E; // bx lr
 		setBL(0x0200B038, (u32)dsiSaveCreate); // dsiSaveCreateAuto
 		setBL(0x0200B088, (u32)dsiSaveOpen);
 		setBL(0x0200B11C, (u32)dsiSaveGetLength);
@@ -9248,8 +9248,8 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		setBL(0x020058E8, (u32)dsiSaveOpen);
 		setBL(0x02005928, (u32)dsiSaveRead);
 		setBL(0x0200595C, (u32)dsiSaveClose);
-		//*(u32*)0x020059E4 = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x020059E8 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x020059E4 = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x020059E8 = 0xE12FFF1E; // bx lr
 		setBL(0x02005A18, (u32)dsiSaveCreate);
 		setBL(0x02005A28, (u32)dsiSaveGetResultCode);
 		setBL(0x02005A4C, (u32)dsiSaveOpen);
@@ -9298,8 +9298,8 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		setBL(0x02005968, (u32)dsiSaveOpen);
 		setBL(0x020059B0, (u32)dsiSaveRead);
 		setBL(0x020059F4, (u32)dsiSaveClose);
-		//*(u32*)0x02005A8C = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x02005A90 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x02005A8C = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x02005A90 = 0xE12FFF1E; // bx lr
 		setBL(0x02005ABC, (u32)dsiSaveCreate);
 		setBL(0x02005ACC, (u32)dsiSaveGetResultCode);
 		setBL(0x02005AE8, (u32)dsiSaveOpen);
@@ -9913,8 +9913,8 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		setBL(0x02007668, (u32)dsiSaveOpen);
 		setBL(0x020076AC, (u32)dsiSaveRead);
 		setBL(0x020076E0, (u32)dsiSaveClose);
-		//*(u32*)0x02007768 = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x0200776C = 0xE12FFF1E; // bx lr
+		// *(u32*)0x02007768 = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x0200776C = 0xE12FFF1E; // bx lr
 		setBL(0x0200779C, (u32)dsiSaveCreate);
 		setBL(0x020077AC, (u32)dsiSaveGetResultCode);
 		setBL(0x020077CC, (u32)dsiSaveOpen);
@@ -10158,10 +10158,10 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		setBL(0x02057B4C, (u32)dsiSaveWrite);
 		setBL(0x02057B64, (u32)dsiSaveClose);
 		setBL(0x02057BB8, 0x02057C54);
-		//*(u32*)0x02057BC4 = 0xE3A00000; // mov r0, #0 (dsiSaveOpenDir)
-		//*(u32*)0x02057BFC = 0xE1A00000; // nop (dsiSaveCloseDir)
-		//*(u32*)0x02057C08 = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x02057C38 = 0xE3A00001; // mov r0, #1 (dsiSaveCreateDirAuto)
+		// *(u32*)0x02057BC4 = 0xE3A00000; // mov r0, #0 (dsiSaveOpenDir)
+		// *(u32*)0x02057BFC = 0xE1A00000; // nop (dsiSaveCloseDir)
+		// *(u32*)0x02057C08 = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x02057C38 = 0xE3A00001; // mov r0, #1 (dsiSaveCreateDirAuto)
 		setBL(0x02057C84, (u32)dsiSaveOpen);
 		setBL(0x02057C94, (u32)dsiSaveGetLength);
 		setBL(0x02057CA8, (u32)dsiSaveSetLength);
@@ -10377,7 +10377,7 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		patchHiHeapDSiWare(0x020193C8, heapEnd); // mov r0, #0x23E0000
 		patchUserSettingsReadDSiWare(0x0201A740);
 		*(u32*)0x0201DDB0 = 0xE1A00000; // nop
-		//*(u32*)0x0203EA70 = 0xE3A00001; // mov r0, #1 (dsiSaveGetArcSrc)
+		// *(u32*)0x0203EA70 = 0xE3A00001; // mov r0, #1 (dsiSaveGetArcSrc)
 		*(u32*)0x02040240 = 0xE1A00000; // nop (Skip Manual screen)
 	}
 
@@ -11206,7 +11206,7 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 			*(u32*)0x0201FD3C = 0xE12FFF1E; // bx lr
 			*(u32*)0x0201FDA8 = 0xE12FFF1E; // bx lr
 			*(u32*)0x0201FE14 = 0xE12FFF1E; // bx lr */
-			//*(u32*)0x020AB800 = 0xE1A00000; // nop
+			// *(u32*)0x020AB800 = 0xE1A00000; // nop
 			*(u32*)0x020BCE44 = 0xE12FFF1E; // bx lr
 		}
 		*(u32*)0x0201FC20 = 0xE12FFF1E; // bx lr (Disable loading sdat file)
@@ -11282,7 +11282,7 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 			*(u32*)0x0201FFB4 = 0xE12FFF1E; // bx lr
 			*(u32*)0x02020020 = 0xE12FFF1E; // bx lr
 			*(u32*)0x0202008C = 0xE12FFF1E; // bx lr */
-			//*(u32*)0x020ABBF0 = 0xE1A00000; // nop
+			// *(u32*)0x020ABBF0 = 0xE1A00000; // nop
 			*(u32*)0x020BD234 = 0xE12FFF1E; // bx lr
 		}
 		*(u32*)0x0201FE98 = 0xE12FFF1E; // bx lr (Disable loading sdat file)
@@ -11334,8 +11334,8 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 	/*else if (strcmp(romTid, "KM4J") == 0) {
 		*(u32*)0x020050A8 = 0xE1A00000; // nop
 		*(u32*)0x0200F91C = 0xE1A00000; // nop (Disable NFTR loading from TWLNAND)
-		//*(u32*)0x020128BC = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x020128C0 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x020128BC = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x020128C0 = 0xE12FFF1E; // bx lr
 		setBL(0x020132D0, (u32)dsiSaveOpen);
 		setBL(0x02013338, (u32)dsiSaveCreate); // dsiSaveCreateAuto
 		setBL(0x02013384, (u32)dsiSaveGetLength);
@@ -11539,12 +11539,12 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 	// Space Ace (USA)
 	else if (strcmp(romTid, "KA6E") == 0) {
 
-		//*(u32*)0x02004B9C = 0x0200002F;
+		// *(u32*)0x02004B9C = 0x0200002F;
 		*(u32*)0x020050D4 = 0xE1A00000; // nop
 		*(u32*)0x020051C8 = 0xE1A00000; // nop (Skip Manual screen)
 		*(u32*)0x02005DD0 = 0xE1A00000; // nop
-		//*(u32*)0x02016458 = 0xE1A00000; // nop
-		//*(u32*)0x0201645C = 0xE1A00000; // nop
+		// *(u32*)0x02016458 = 0xE1A00000; // nop
+		// *(u32*)0x0201645C = 0xE1A00000; // nop
 		*(u32*)0x0201F874 = 0xE1A00000; // nop
 		setBL(0x0201F8BC, (u32)dsiSaveOpen);
 		setBL(0x0201F8D4, (u32)dsiSaveRead);
@@ -11589,7 +11589,7 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		*(u32*)0x0203DDCC = 0xE1A00000; // nop
 		*(u32*)0x0203DDD0 = 0xE1A00000; // nop
 		*(u32*)0x0203DDD4 = 0xE1A00000; // nop
-		//*(u32*)0x0203E9B4 = 0xE1A00000; // nop (Forgot what this does)
+		// *(u32*)0x0203E9B4 = 0xE1A00000; // nop (Forgot what this does)
 		*(u32*)0x02040888 = 0xE1A00000; // nop
 	}
 
@@ -11769,8 +11769,8 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 	else if (strcmp(romTid, "K4DE") == 0) {
 		if (ndsHeader->romversion == 1) {
 			*(u32*)0x0200698C = 0xE1A00000; // nop
-			//*(u32*)0x0203701C = 0xE3A00001; // mov r0, #1
-			//*(u32*)0x02037020 = 0xE12FFF1E; // bx lr
+			// *(u32*)0x0203701C = 0xE3A00001; // mov r0, #1
+			// *(u32*)0x02037020 = 0xE12FFF1E; // bx lr
 			setBL(0x02037560, (u32)dsiSaveOpen);
 			*(u32*)0x02037580 = 0xE1A00000; // nop
 			setBL(0x020375B0, (u32)dsiSaveCreate);
@@ -11801,8 +11801,8 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 			*(u32*)0x020C7E08 = 0xE1A00000; // nop
 		} else {
 			*(u32*)0x0200695C = 0xE1A00000; // nop
-			//*(u32*)0x0203609C = 0xE3A00001; // mov r0, #1
-			//*(u32*)0x020360A0 = 0xE12FFF1E; // bx lr
+			// *(u32*)0x0203609C = 0xE3A00001; // mov r0, #1
+			// *(u32*)0x020360A0 = 0xE12FFF1E; // bx lr
 			setBL(0x020364A4, (u32)dsiSaveOpen);
 			*(u32*)0x020364C0 = 0xE1A00000; // nop
 			setBL(0x020364F0, (u32)dsiSaveCreate);
@@ -11837,8 +11837,8 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 	// Sudoku (Europe, Australia) (Rev 1)
 	else if (strcmp(romTid, "K4DV") == 0) {
 		*(u32*)0x0200698C = 0xE1A00000; // nop
-		//*(u32*)0x020360E8 = 0xE3A00001; // mov r0, #1
-		//*(u32*)0x020360EC = 0xE12FFF1E; // bx lr
+		// *(u32*)0x020360E8 = 0xE3A00001; // mov r0, #1
+		// *(u32*)0x020360EC = 0xE12FFF1E; // bx lr
 		setBL(0x020375AC, (u32)dsiSaveOpen);
 		*(u32*)0x020375CC = 0xE1A00000; // nop
 		setBL(0x020375FC, (u32)dsiSaveCreate);
@@ -12106,13 +12106,13 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 			setBL(0x0205A778, (u32)dsiSaveGetLength);
 			setBL(0x0205A7B0, (u32)dsiSaveRead);
 			setBL(0x0205A7CC, (u32)dsiSaveClose);
-			//*(u32*)0x0205A83C = 0xE12FFF1E; // bx lr
+			// *(u32*)0x0205A83C = 0xE12FFF1E; // bx lr
 			setBL(0x0205A864, (u32)dsiSaveCreate);
 			setBL(0x0205A874, (u32)dsiSaveGetResultCode);
 			setBL(0x0205A89C, (u32)dsiSaveOpen);
 			setBL(0x0205A8C0, (u32)dsiSaveWrite);
 			setBL(0x0205A8F0, (u32)dsiSaveClose);
-			//*(u32*)0x0205A92C = 0xE12FFF1E; // bx lr
+			// *(u32*)0x0205A92C = 0xE12FFF1E; // bx lr
 			setBL(0x0205A95C, (u32)dsiSaveOpen);
 			setBL(0x0205A99C, (u32)dsiSaveSeek);
 			setBL(0x0205A9DC, (u32)dsiSaveWrite);
@@ -12127,13 +12127,13 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 			setBL(0x0205A764, (u32)dsiSaveGetLength);
 			setBL(0x0205A79C, (u32)dsiSaveRead);
 			setBL(0x0205A7B8, (u32)dsiSaveClose);
-			//*(u32*)0x0205A828 = 0xE12FFF1E; // bx lr
+			// *(u32*)0x0205A828 = 0xE12FFF1E; // bx lr
 			setBL(0x0205A850, (u32)dsiSaveCreate);
 			setBL(0x0205A860, (u32)dsiSaveGetResultCode);
 			setBL(0x0205A888, (u32)dsiSaveOpen);
 			setBL(0x0205A8AC, (u32)dsiSaveWrite);
 			setBL(0x0205A8DC, (u32)dsiSaveClose);
-			//*(u32*)0x0205A918 = 0xE12FFF1E; // bx lr
+			// *(u32*)0x0205A918 = 0xE12FFF1E; // bx lr
 			setBL(0x0205A948, (u32)dsiSaveOpen);
 			setBL(0x0205A988, (u32)dsiSaveSeek);
 			setBL(0x0205A9C8, (u32)dsiSaveWrite);
@@ -12302,7 +12302,7 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 	// Crashes on white screens when going to menu
 	/*else if ((strcmp(romTid, "K72E") == 0 || strcmp(romTid, "K72V") == 0) && extendedMemory2) {
 
-		//*(u32*)0x02009A84 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x02009A84 = 0xE12FFF1E; // bx lr
 		setBL(0x02009AC0, (u32)dsiSaveOpen);
 		setBL(0x02009AE0, (u32)dsiSaveGetLength);
 		setBL(0x02009B48, (u32)dsiSaveClose);
@@ -12394,7 +12394,7 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 	// Unable to read saved data
 	else if (strcmp(romTid, "K6PJ") == 0) {
 		*(u32*)0x02006E84 = 0xE12FFF1E; // bx lr (Skip NFTR font rendering)
-		//*(u32*)0x02007344 = 0xE1A00000; // nop (Skip directory browse)
+		// *(u32*)0x02007344 = 0xE1A00000; // nop (Skip directory browse)
 		*(u32*)0x020092D4 = 0xE3A00000; // mov r0, #0 (Disable NFTR loading from TWLNAND)
 		for (int i = 0; i < 11; i++) { // Skip Manual screen
 			u32* offset = (u32*)0x0200A608;
@@ -12821,8 +12821,8 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		setBL(0x0200EA8C, (u32)dsiSaveOpen);
 		setBL(0x0200EAE4, (u32)dsiSaveRead);
 		setBL(0x0200EB28, (u32)dsiSaveClose);
-		//*(u32*)0x0200EBC8 = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x0200EBCC = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0200EBC8 = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x0200EBCC = 0xE12FFF1E; // bx lr
 		setBL(0x0200EBF4, (u32)dsiSaveCreate);
 		setBL(0x0200EC04, (u32)dsiSaveGetResultCode);
 		setBL(0x0200EC28, (u32)dsiSaveOpen);
@@ -12888,8 +12888,8 @@ void patchDSiModeToDSMode(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		setBL(0x0200ED4C, (u32)dsiSaveOpen);
 		setBL(0x0200EDA0, (u32)dsiSaveRead);
 		setBL(0x0200EDF0, (u32)dsiSaveClose);
-		//*(u32*)0x0200EE98 = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x0200EE9C = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0200EE98 = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x0200EE9C = 0xE12FFF1E; // bx lr
 		setBL(0x0200EEC0, (u32)dsiSaveCreate);
 		setBL(0x0200EED0, (u32)dsiSaveGetResultCode);
 		setBL(0x0200EEEC, (u32)dsiSaveOpen);
@@ -13206,16 +13206,16 @@ void patchBinary(cardengineArm9* ce9, const tNDSHeader* ndsHeader, module_params
 
 	const char* romTid = getRomTid(ndsHeader);
 
-	const u32* dsiSaveGetResultCode = ce9->patches->dsiSaveGetResultCode;
+	// const u32* dsiSaveGetResultCode = ce9->patches->dsiSaveGetResultCode;
 	const u32* dsiSaveCreate = ce9->patches->dsiSaveCreate;
-	const u32* dsiSaveDelete = ce9->patches->dsiSaveDelete;
-	const u32* dsiSaveGetInfo = ce9->patches->dsiSaveGetInfo;
-	const u32* dsiSaveSetLength = ce9->patches->dsiSaveSetLength;
+	// const u32* dsiSaveDelete = ce9->patches->dsiSaveDelete;
+	// const u32* dsiSaveGetInfo = ce9->patches->dsiSaveGetInfo;
+	// const u32* dsiSaveSetLength = ce9->patches->dsiSaveSetLength;
 	const u32* dsiSaveOpen = ce9->patches->dsiSaveOpen;
-	const u32* dsiSaveOpenR = ce9->patches->dsiSaveOpenR;
+	// const u32* dsiSaveOpenR = ce9->patches->dsiSaveOpenR;
 	const u32* dsiSaveClose = ce9->patches->dsiSaveClose;
-	const u32* dsiSaveGetLength = ce9->patches->dsiSaveGetLength;
-	const u32* dsiSaveSeek = ce9->patches->dsiSaveSeek;
+	// const u32* dsiSaveGetLength = ce9->patches->dsiSaveGetLength;
+	// const u32* dsiSaveSeek = ce9->patches->dsiSaveSeek;
 	const u32* dsiSaveRead = ce9->patches->dsiSaveRead;
 	const u32* dsiSaveWrite = ce9->patches->dsiSaveWrite;
 
@@ -13478,13 +13478,13 @@ void patchBinary(cardengineArm9* ce9, const tNDSHeader* ndsHeader, module_params
 
     // Pokemon Dash (Japan)
 	//else if (strcmp(romTid, "APDJ") == 0) {
-		//*(u32*)0x0206AE70 = 0xE3A00000; //mov r0, #0
-        //*(u32*)0x0206D2C4 = 0xE3A00001; //mov r0, #1
-		//*(u32*)0x0206AE74 = 0xe12fff1e; //bx lr
+		// *(u32*)0x0206AE70 = 0xE3A00000; //mov r0, #0
+        // *(u32*)0x0206D2C4 = 0xE3A00001; //mov r0, #1
+		// *(u32*)0x0206AE74 = 0xe12fff1e; //bx lr
         
-        //*(u32*)0x02000B94 = 0xE1A00000; //nop
+        // *(u32*)0x02000B94 = 0xE1A00000; //nop
 
-		//*(u32*)0x020D5010 = 0xe12fff1e; //bx lr
+		// *(u32*)0x020D5010 = 0xe12fff1e; //bx lr
 	//}
 
     // Pokemon Dash
@@ -13534,13 +13534,13 @@ void patchBinary(cardengineArm9* ce9, const tNDSHeader* ndsHeader, module_params
             *(((u8*)0x0206D2C4)+i) = pdash_patch_chars[i];    
         }*/
         
-        //*((u32*)0x02000BB0) = 0xE1A00000; //nop 
+        // *((u32*)0x02000BB0) = 0xE1A00000; //nop 
     
-		//*(u32*)0x0206D2C4 = 0xE3A00000; //mov r0, #0
-        //*(u32*)0x0206D2C4 = 0xE3A00001; //mov r0, #1
-		//*(u32*)0x0206D2C8 = 0xe12fff1e; //bx lr
+		// *(u32*)0x0206D2C4 = 0xE3A00000; //mov r0, #0
+        // *(u32*)0x0206D2C4 = 0xE3A00001; //mov r0, #1
+		// *(u32*)0x0206D2C8 = 0xe12fff1e; //bx lr
         
-		//*(u32*)0x020D5010 = 0xe12fff1e; //bx lr
+		// *(u32*)0x020D5010 = 0xe12fff1e; //bx lr
 	//}
 
     /* // Pokemon Dash (Kiosk Demo)
@@ -13624,8 +13624,8 @@ void patchBinary(cardengineArm9* ce9, const tNDSHeader* ndsHeader, module_params
 		*getOffsetFromBL((u32*)0x02007500) = 0xE12FFF1E; // bx lr
 		*getOffsetFromBL((u32*)0x020075C4) = 0xE12FFF1E; // bx lr
 		*(u32*)0x0202D25C = 0xEB00007C; // bl 0x0202D454 (Skip Manual screen)
-		//*(u32*)0x0202D2EC = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x0202D314 = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x0202D2EC = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x0202D314 = 0xE3A00000; // mov r0, #0
 		setBL(0x0203A248, (u32)dsiSaveOpen);
 		setBL(0x0203A26C, (u32)dsiSaveClose);
 		*(u32*)0x0203A288 = 0xE3A00000; // mov r0, #0

--- a/retail/bootloaderi/source/arm7/decompress.c
+++ b/retail/bootloaderi/source/arm7/decompress.c
@@ -163,7 +163,7 @@ static u32 decompressBinary(u8 *aMainMemory, u32 aCodeLength, u32 aMemOffset) {
 static u32 decompressIBinary(unsigned char *pak_buffer, unsigned int pak_len) {
   unsigned char *raw_buffer, *pak, *raw, *pak_end, *raw_end;
   unsigned int   raw_len, len, pos, inc_len, hdr_len, enc_len, dec_len;
-  unsigned char  flags, mask;
+  unsigned char  flags = 0, mask;
 
   inc_len = *(unsigned int *)(pak_buffer + pak_len - 4);
   if (!inc_len) {
@@ -201,7 +201,7 @@ static u32 decompressIBinary(unsigned char *pak_buffer, unsigned int pak_len) {
 
   for (len = 0; len < dec_len; len++) *raw++ = *pak++;
 
-  BLZ_Invert(pak_buffer + dec_len, pak_len);
+  BLZ_Invert((char *)pak_buffer + dec_len, pak_len);
 
   mask = 0;
 
@@ -225,11 +225,14 @@ static u32 decompressIBinary(unsigned char *pak_buffer, unsigned int pak_len) {
         len = raw_end - raw;
       }
       pos = (pos & 0xFFF) + 3;
-      while (len--) *raw++ = *(raw - pos);
+      while (len--) {
+		*raw = *(raw - pos);
+		++raw;
+	  }
     }
   }
 
-  BLZ_Invert(raw_buffer + dec_len, raw_len - dec_len);
+  BLZ_Invert((char *)raw_buffer + dec_len, raw_len - dec_len);
 
 	tonccpy(pak_buffer, raw_buffer, raw_len);
 	toncset(raw_buffer, 0, raw_len);

--- a/retail/bootloaderi/source/arm7/find_arm9.c
+++ b/retail/bootloaderi/source/arm7/find_arm9.c
@@ -217,7 +217,7 @@ static const u16 sleepSignatureThumb4[4]        = {0xB530, 0xB08D, 0x1C04, 0xA80
 static const u32 sleepSignature5[4]        = {0xE92D4030, 0xE24DD034, 0xE28D4008, 0xE1A05000}; // sdk5
 static const u16 sleepSignatureThumb5[4]        = {0xB578, 0xB08D, 0xAE02, 0x1C05}; // sdk5
 
-static const u16 sleepConstantValue = {0x82EA};
+static const u16 sleepConstantValue[1] = {0x82EA};
 
 // Init Heap
 static const u32 initHeapEndSignature1[2]              = {0x27FF000, 0x37F8000};
@@ -383,12 +383,12 @@ u32* findDsiModeCheck2Offset(const u32* dsiModeCheckOffset, bool usesThumb) {
 
     u32* offset = NULL;
 	if (usesThumb) {
-		offset = findOffsetThumb(
+		offset = (u32*)findOffsetThumb(
 			(u16*)dsiModeCheckOffset+16, iUncompressedSize,//ndsHeader->arm9binarySize,
 			dsiModeCheck2SignatureThumb, 4
 		);
 		if (!offset) {
-			offset = findOffsetThumb(
+			offset = (u32*)findOffsetThumb(
 				(u16*)dsiModeCheckOffset+16, iUncompressedSize,//ndsHeader->arm9binarySize,
 				dsiModeCheck2SignatureThumbAlt, 4
 			);
@@ -423,20 +423,20 @@ u32* findCardHashInitOffset(const tNDSHeader* ndsHeader, const module_params_t* 
 	u32* offset = NULL;
 	if (moduleParams->sdk_version > 0x5008000) {
 		offset = findOffset(
-			*(u32*)0x02FFE1C8, iUncompressedSizei,//ndsHeader->arm9binarySize,
+			(u32*)(*(u32*)0x02FFE1C8), iUncompressedSizei,//ndsHeader->arm9binarySize,
 			cardHashInitSignature, 3
 		);
 
 		if (!offset) {
 			offset = findOffset(
-				*(u32*)0x02FFE1C8, iUncompressedSizei,//ndsHeader->arm9binarySize,
+				(u32*)(*(u32*)0x02FFE1C8), iUncompressedSizei,//ndsHeader->arm9binarySize,
 				cardHashInitSignatureAlt, 4
 			);
 		}
 
 		if (!offset) {
 			offset = findOffset(
-				*(u32*)0x02FFE1C8, iUncompressedSizei,//ndsHeader->arm9binarySize,
+				(u32*)(*(u32*)0x02FFE1C8), iUncompressedSizei,//ndsHeader->arm9binarySize,
 				cardHashInitSignatureAlt2, 4
 			);
 		}
@@ -477,13 +477,13 @@ u16* findCardHashInitOffsetThumb(const tNDSHeader* ndsHeader, const module_param
 	u16* offset = NULL;
 	if (moduleParams->sdk_version > 0x5008000) {
 		offset = findOffsetThumb(
-			*(u32*)0x02FFE1C8, iUncompressedSizei,//ndsHeader->arm9binarySize,
+			(u16*)(*(u32*)0x02FFE1C8), iUncompressedSizei,//ndsHeader->arm9binarySize,
 			cardHashInitSignatureThumb, 3
 		);
 
 		if (!offset) {
 			offset = findOffsetThumb(
-				*(u32*)0x02FFE1C8, iUncompressedSizei,//ndsHeader->arm9binarySize,
+				(u16*)(*(u32*)0x02FFE1C8), iUncompressedSizei,//ndsHeader->arm9binarySize,
 				cardHashInitSignatureThumbAlt, 3
 			);
 		}
@@ -565,7 +565,7 @@ u32* findCardReadEndOffsetType0(const tNDSHeader* ndsHeader, const module_params
 u32* findCardReadEndOffsetType1(const tNDSHeader* ndsHeader, u32 startOffset) {
 	dbg_printf("findCardReadEndOffsetType1:\n");
 
-	const char* romTid = getRomTid(ndsHeader);
+	// const char* romTid = getRomTid(ndsHeader);
 
 	u32* cardReadEndOffset = NULL;
 	//readType = 1;
@@ -2336,8 +2336,8 @@ u32* findWaitSysCyclesOffset(const tNDSHeader* ndsHeader) {
 
 u32* findSleepOffset(const tNDSHeader* ndsHeader, const module_params_t* moduleParams, bool usesThumb, u32* usesThumbPtr) {
 	dbg_printf("findSleepOffset\n");
-    u32* sleepSignature = sleepSignature2;
-    u16* sleepSignatureThumb = sleepSignatureThumb2;
+    const u32* sleepSignature = sleepSignature2;
+    const u16* sleepSignatureThumb = sleepSignatureThumb2;
           
     if (moduleParams->sdk_version > 0x3000000 && moduleParams->sdk_version < 0x5000000) { 
         sleepSignature = sleepSignature4;
@@ -2351,8 +2351,8 @@ u32* findSleepOffset(const tNDSHeader* ndsHeader, const module_params_t* moduleP
     u32 * sleepOffset = NULL;
     
     if(usesThumb) {
-  		sleepOffset = findOffsetThumb(
-      		(u32*)ndsHeader->arm9destination, iUncompressedSize,//ndsHeader->arm9binarySize,
+  		sleepOffset = (u32*)findOffsetThumb(
+      		(u16*)ndsHeader->arm9destination, iUncompressedSize,//ndsHeader->arm9binarySize,
             sleepSignatureThumb, 4
         );
 		if (sleepOffset) {
@@ -2373,8 +2373,8 @@ u32* findSleepOffset(const tNDSHeader* ndsHeader, const module_params_t* moduleP
 	}
 
 	if (!sleepOffset && usesThumb && moduleParams->sdk_version > 0x5000000) {
-  		sleepOffset = findOffsetThumb(
-      		(u32*)ndsHeader->arm9destination, iUncompressedSize,//ndsHeader->arm9binarySize,
+  		sleepOffset = (u32*)findOffsetThumb(
+      		(u16*)ndsHeader->arm9destination, iUncompressedSize,//ndsHeader->arm9binarySize,
             sleepSignatureThumb4, 4
         );
 		if (sleepOffset) {
@@ -2391,8 +2391,8 @@ u32* findSleepOffset(const tNDSHeader* ndsHeader, const module_params_t* moduleP
 	}
 
     while(sleepOffset!=NULL) {
-    	u32* sleepEndOffset = findOffsetThumb(
-    		sleepOffset, 0x200,
+    	u16* sleepEndOffset = findOffsetThumb(
+    		(u16*)sleepOffset, 0x200,
     		sleepConstantValue, 1
     	);
         if (sleepEndOffset) {
@@ -2403,8 +2403,8 @@ u32* findSleepOffset(const tNDSHeader* ndsHeader, const module_params_t* moduleP
         } 
         
         if(usesThumb) {
-      		sleepOffset = findOffsetThumb(
-          		sleepOffset+1, iUncompressedSize,//ndsHeader->arm9binarySize,
+      		sleepOffset = (u32*)findOffsetThumb(
+          		(u16*)(sleepOffset+1), iUncompressedSize,//ndsHeader->arm9binarySize,
                 sleepSignatureThumb, 4
             );
       	} else {
@@ -2428,14 +2428,14 @@ u32* findSleepOffset(const tNDSHeader* ndsHeader, const module_params_t* moduleP
 u32* findCardEndReadDmaSdk5(const tNDSHeader* ndsHeader, const module_params_t* moduleParams, bool usesThumb) {
 	dbg_printf("findCardEndReadDmaSdk5\n");
 
-    u16* cardEndReadDmaSignatureThumb = cardEndReadDmaSignatureThumb5;
-    u32* cardEndReadDmaSignature = cardEndReadDmaSignature5;
+    const u16* cardEndReadDmaSignatureThumb = cardEndReadDmaSignatureThumb5;
+    const u32* cardEndReadDmaSignature = cardEndReadDmaSignature5;
 
     u32 * offset = NULL;
     
     if(usesThumb) {
-  		offset = findOffsetThumb(
-      		(u32*)ndsHeader->arm9destination, iUncompressedSize,//ndsHeader->arm9binarySize,
+  		offset = (u32*)findOffsetThumb(
+      		(u16*)ndsHeader->arm9destination, iUncompressedSize,//ndsHeader->arm9binarySize,
             cardEndReadDmaSignatureThumb, 4
         );
     } else {
@@ -2462,7 +2462,7 @@ u32* findCardEndReadDma(const tNDSHeader* ndsHeader, const module_params_t* modu
         return findCardEndReadDmaSdk5(ndsHeader,moduleParams,usesThumb);
     }     
 
-	u32* offsetDmaHandler = NULL;
+	const u32* offsetDmaHandler = NULL;
 	if (moduleParams->sdk_version < 0x4000000) {
 		offsetDmaHandler = cardReadDmaEndOffset+8;
 	}
@@ -2489,21 +2489,21 @@ u32* findCardEndReadDma(const tNDSHeader* ndsHeader, const module_params_t* modu
     u32 * offset = NULL;
 
     if (usesThumb) {
-  		offset = findOffsetThumb(
-      		((u32)*offsetDmaHandler)-1, 0x200,//ndsHeader->arm9binarySize,
+  		offset = (u32*)findOffsetThumb(
+      		(u16*)((*offsetDmaHandler)-1), 0x200,//ndsHeader->arm9binarySize,
             cardEndReadDmaSignatureThumb4, 2
         );
     } else {
   		offset = findOffset(
-      		*offsetDmaHandler, 0x200,//ndsHeader->arm9binarySize,
+      		(u32*)*offsetDmaHandler, 0x200,//ndsHeader->arm9binarySize,
             cardEndReadDmaSignature4, 1
         ); 
     } 
 
 	if (!offset) {
 		if (usesThumb) {
-			offset = findOffsetThumb(
-				((u32)*offsetDmaHandler)-1, 0x200,//ndsHeader->arm9binarySize,
+			offset = (u32*)findOffsetThumb(
+				(u16*)((*offsetDmaHandler)-1), 0x200,//ndsHeader->arm9binarySize,
 				cardEndReadDmaSignatureThumb3, 1
 			);
 		} else {
@@ -2554,8 +2554,8 @@ u32* findCardSetDmaSdk5(const tNDSHeader* ndsHeader, const module_params_t* modu
             currentOffset = cardSetDmaEndOffset+2;
              if(usesThumb) {
                   dbg_printf("cardSetDmaSignatureStartThumb used: ");
-            		startOffset = findOffsetBackwardsThumb(
-                		cardSetDmaEndOffset, 0x90,
+            		startOffset = (u32*)findOffsetBackwardsThumb(
+                		(u16*)cardSetDmaEndOffset, 0x90,
                       cardSetDmaSignatureStartThumb5, 2
                   );
               } else {
@@ -2579,10 +2579,12 @@ u32* findCardSetDmaSdk5(const tNDSHeader* ndsHeader, const module_params_t* modu
                 dbg_printf("\n");*/
                 
                 return startOffset;
-            }                          
-        }     
-    } 
-}    
+            }
+        }
+    }
+
+    return NULL;
+}
 
 u32* findCardSetDma(const tNDSHeader* ndsHeader, const module_params_t* moduleParams, bool usesThumb) {
 	dbg_printf("findCardSetDma\n");
@@ -2591,8 +2593,8 @@ u32* findCardSetDma(const tNDSHeader* ndsHeader, const module_params_t* modulePa
         return findCardSetDmaSdk5(ndsHeader,moduleParams,usesThumb);
     } 
     
-    //u16* cardSetDmaSignatureStartThumb = cardSetDmaSignatureStartThumb4;
-    u32* cardSetDmaSignatureStart = cardSetDmaSignatureStart4;
+    //const u16* cardSetDmaSignatureStartThumb = cardSetDmaSignatureStartThumb4;
+    const u32* cardSetDmaSignatureStart = cardSetDmaSignatureStart4;
 	int cardSetDmaSignatureStartLen = 3;
 
     if (moduleParams->sdk_version < 0x2004000) {
@@ -2646,8 +2648,8 @@ u32* findCardSetDma(const tNDSHeader* ndsHeader, const module_params_t* modulePa
 
     if(usesThumb) {
         dbg_printf("cardSetDmaSignatureStartThumb used: ");
-  		offset = findOffsetBackwardsThumb(
-      		cardSetDmaEndOffset, 0x60,
+  		offset = (u32*)findOffsetBackwardsThumb(
+      		(u16*)cardSetDmaEndOffset, 0x60,
             cardSetDmaSignatureStartThumb4, 4
         );
     } else {
@@ -2659,8 +2661,8 @@ u32* findCardSetDma(const tNDSHeader* ndsHeader, const module_params_t* modulePa
     }
 
 	if (!offset && usesThumb) {
-  		offset = findOffsetBackwardsThumb(
-      		cardSetDmaEndOffset, 0x60,
+  		offset = (u32*)findOffsetBackwardsThumb(
+      		(u16*)cardSetDmaEndOffset, 0x60,
             cardSetDmaSignatureStartThumb3, 4
         );
 	}
@@ -2683,7 +2685,7 @@ u32* findCardSetDma(const tNDSHeader* ndsHeader, const module_params_t* modulePa
 
 u32* findResetOffset(const tNDSHeader* ndsHeader, const module_params_t* moduleParams, bool* softResetMb) {
 	dbg_printf("findResetOffset\n");
-    u32* resetSignature = resetSignature2;
+    const u32* resetSignature = resetSignature2;
 
     if (moduleParams->sdk_version > 0x4008000 && moduleParams->sdk_version < 0x5000000) { 
         resetSignature = resetSignature4;
@@ -2799,7 +2801,7 @@ u32* findResetOffset(const tNDSHeader* ndsHeader, const module_params_t* moduleP
     } 
     
     while(resetOffset!=NULL) {
-    	u32* resetEndOffset = findOffsetThumb(
+    	u32* resetEndOffset = findOffset(
     		resetOffset, 0x200,
     		(isSdk5(moduleParams) ? resetConstant5 : resetConstant), 1
     	);
@@ -2875,7 +2877,7 @@ u32* findMbkWramBOffset(const tNDSHeader* ndsHeader, const module_params_t* modu
 	u32* offset = NULL;
 	if (moduleParams->sdk_version > 0x5008000) {
 		offset = findOffset(
-			*(u32*)0x02FFE1C8, iUncompressedSizei,//ndsHeader->arm9binarySize,
+			(u32*)(*(u32*)0x02FFE1C8), iUncompressedSizei,//ndsHeader->arm9binarySize,
 			mbkWramBConstant, 1
 		);
 	} else {
@@ -2908,7 +2910,7 @@ u16* findMbkWramBOffsetThumb(const tNDSHeader* ndsHeader, const module_params_t*
 	u16* offset = NULL;
 	if (moduleParams->sdk_version > 0x5008000) {
 		offset = (u16*)findOffset(
-			*(u32*)0x02FFE1C8, iUncompressedSizei,//ndsHeader->arm9binarySize,
+			(u32*)(*(u32*)0x02FFE1C8), iUncompressedSizei,//ndsHeader->arm9binarySize,
 			mbkWramBConstant, 1
 		);
 	} else {
@@ -2942,7 +2944,7 @@ u32* findMbkWramBOffsetBoth(const tNDSHeader* ndsHeader, const module_params_t* 
 	u32* offset = NULL;
 	if (moduleParams->sdk_version > 0x5008000) {
 		offset = findOffset(
-			*(u32*)0x02FFE1C8, iUncompressedSizei,//ndsHeader->arm9binarySize,
+			(u32*)*(u32*)0x02FFE1C8, iUncompressedSizei,//ndsHeader->arm9binarySize,
 			mbkWramBConstant, 1
 		);
 	} else {

--- a/retail/bootloaderi/source/arm7/ips.c
+++ b/retail/bootloaderi/source/arm7/ips.c
@@ -99,10 +99,6 @@ bool ipsHasOverlayPatch(const tNDSHeader* ndsHeader, u8* ipsbyte) {
 			ipson += 2;
 			totalrepeats = ipsbyte[ipson] * 256 + ipsbyte[ipson + 1];
 			ipson += 2;
-			u8 repeatbyte[totalrepeats];
-			for (int ontime = 0; ontime < totalrepeats; ontime++) {
-				repeatbyte[ontime] = ipsbyte[ipson];
-			}
 			ipson++;
 		} else {
 			totalrepeats = ipsbyte[ipson] * 256 + ipsbyte[ipson + 1];

--- a/retail/bootloaderi/source/arm7/patch_common.c
+++ b/retail/bootloaderi/source/arm7/patch_common.c
@@ -115,7 +115,7 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		*(u32*)0x0200E40C = 0xE12FFF1E; // bx lr
 		*(u32*)0x0200E54C = 0xE3A00001; // mov r0, #1
 		*(u32*)0x0200E550 = 0xE12FFF1E; // bx lr */
-		//*(u32*)0x0200E010 = 0xE3A00001; // mov r0, #1 (dsiSaveFreeSpaceAvailable)
+		// *(u32*)0x0200E010 = 0xE3A00001; // mov r0, #1 (dsiSaveFreeSpaceAvailable)
 		setBL(0x0200E0D4, (u32)dsiSaveCreate);
 		setBL(0x0200E0E4, (u32)dsiSaveOpen);
 		setBL(0x0200E11C, (u32)dsiSaveSetLength);
@@ -143,7 +143,7 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		*(u32*)0x0200E3BC = 0xE12FFF1E; // bx lr
 		*(u32*)0x0200E4FC = 0xE3A00001; // mov r0, #1
 		*(u32*)0x0200E500 = 0xE12FFF1E; // bx lr */
-		//*(u32*)0x0200DFC0 = 0xE3A00001; // mov r0, #1 (dsiSaveFreeSpaceAvailable)
+		// *(u32*)0x0200DFC0 = 0xE3A00001; // mov r0, #1 (dsiSaveFreeSpaceAvailable)
 		setBL(0x0200E084, (u32)dsiSaveCreate);
 		setBL(0x0200E094, (u32)dsiSaveOpen);
 		setBL(0x0200E0CC, (u32)dsiSaveSetLength);
@@ -470,8 +470,8 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 	// Anonymous Notes 2: From The Abyss (USA & Europe)
 	else if ((strncmp(romTid, "KVI", 3) == 0 || strncmp(romTid, "KV2", 3) == 0)
 	  && ndsHeader->gameCode[3] != 'J' && saveOnFlashcard) {
-		//*(u32*)0x02023DB0 = 0xE3A00001; // mov r0, #1
-		//*(u32*)0x02023DB4 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x02023DB0 = 0xE3A00001; // mov r0, #1
+		// *(u32*)0x02023DB4 = 0xE12FFF1E; // bx lr
 		setBL(0x02024220, (u32)dsiSaveOpen);
 		setBL(0x02024258, (u32)dsiSaveCreate);
 		setBL(0x02024268, (u32)dsiSaveGetResultCode);
@@ -496,7 +496,7 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		setBL(0x020244F4, (u32)dsiSaveClose);
 		if (ndsHeader->gameCode[2] == 'I') {
 			if (ndsHeader->gameCode[3] == 'E') {
-				//*(u32*)0x020CE830 = 0xE12FFF1E; // bx lr
+				// *(u32*)0x020CE830 = 0xE12FFF1E; // bx lr
 				*(u32*)0x020CFCD0 = 0xE1A00000; // nop (Disable NFTR loading from TWLNAND)
 			} else {
 				*(u32*)0x020CFAE0 = 0xE1A00000; // nop (Disable NFTR loading from TWLNAND)
@@ -651,10 +651,10 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 	// Army Defender (USA)
 	// Army Defender (Europe)
 	else if (strncmp(romTid, "KAY", 3) == 0 && saveOnFlashcard) {
-		//*(u32*)0x020051BC = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x020051C0 = 0xE12FFF1E; // bx lr
-		//*(u32*)0x02005204 = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x02005208 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x020051BC = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x020051C0 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x02005204 = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x02005208 = 0xE12FFF1E; // bx lr
 		setBL(0x02020A28, (u32)dsiSaveCreate);
 		setBL(0x02020A38, (u32)dsiSaveOpen);
 		setBL(0x02020A8C, (u32)dsiSaveWrite);
@@ -771,14 +771,14 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		setBL(0x020267D4, (u32)dsiSaveOpen);
 		setBL(0x020267E8, (u32)dsiSaveCreate);
 		setBL(0x02026814, (u32)dsiSaveOpen);
-		//*(u32*)0x02026834 = 0xE3A01B0B; // mov r1, #0x2C00
+		// *(u32*)0x02026834 = 0xE3A01B0B; // mov r1, #0x2C00
 		setBL(0x0202683C, (u32)dsiSaveSetLength);
 		setBL(0x0202684C, (u32)dsiSaveClose);
 		setBL(0x02026870, (u32)dsiSaveWrite);
 		setBL(0x0202687C, (u32)dsiSaveGetLength);
 		*(u32*)0x02026880 = 0xE1A02000; // mov r2, r0
 		*(u32*)0x02026884 = 0xE3A01000; // mov r1, #0
-		//*(u32*)0x02026888 = 0xE3A03000; // mov r3, #0
+		// *(u32*)0x02026888 = 0xE3A03000; // mov r3, #0
 		setBL(0x020268B8, (u32)dsiSaveSeek);
 		setBL(0x020268D4, (u32)dsiSaveRead);
 		setBL(0x02026BDC, (u32)dsiSaveSeek);
@@ -933,8 +933,8 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 	// Bomberman Blitz (USA)
 	else if (strcmp(romTid, "KBBE") == 0 && saveOnFlashcard) {
 		tonccpy((u32*)0x02009670, dsiSaveGetResultCode, 0xC);
-		//*(u32*)0x020437AC = 0xE3A00001; // mov r0, #1
-		//*(u32*)0x020437B0 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x020437AC = 0xE3A00001; // mov r0, #1
+		// *(u32*)0x020437B0 = 0xE12FFF1E; // bx lr
 		setBL(0x02043950, (u32)dsiSaveOpen);
 		setBL(0x020439D0, (u32)dsiSaveCreate);
 		setBL(0x02043A5C, (u32)dsiSaveWrite);
@@ -948,8 +948,8 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 	// Bomberman Blitz (Europe, Australia)
 	else if (strcmp(romTid, "KBBV") == 0 && saveOnFlashcard) {
 		tonccpy((u32*)0x02009670, dsiSaveGetResultCode, 0xC);
-		//*(u32*)0x02043878 = 0xE3A00001; // mov r0, #1
-		//*(u32*)0x0204387C = 0xE12FFF1E; // bx lr
+		// *(u32*)0x02043878 = 0xE3A00001; // mov r0, #1
+		// *(u32*)0x0204387C = 0xE12FFF1E; // bx lr
 		setBL(0x02043A1C, (u32)dsiSaveOpen);
 		setBL(0x02043A9C, (u32)dsiSaveCreate);
 		setBL(0x02043B28, (u32)dsiSaveWrite);
@@ -963,8 +963,8 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 	// Itsudemo Bomberman (Japan)
 	else if (strcmp(romTid, "KBBJ") == 0 && saveOnFlashcard) {
 		tonccpy((u32*)0x02009670, dsiSaveGetResultCode, 0xC);
-		//*(u32*)0x020434D8 = 0xE3A00001; // mov r0, #1
-		//*(u32*)0x020434DC = 0xE12FFF1E; // bx lr
+		// *(u32*)0x020434D8 = 0xE3A00001; // mov r0, #1
+		// *(u32*)0x020434DC = 0xE12FFF1E; // bx lr
 		setBL(0x0204367C, (u32)dsiSaveOpen);
 		setBL(0x020436FC, (u32)dsiSaveCreate);
 		setBL(0x02043788, (u32)dsiSaveWrite);
@@ -997,13 +997,13 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 	// Art Style: BOXLIFE (USA)
 	else if (strcmp(romTid, "KAHE") == 0 && saveOnFlashcard) {
 		setBL(0x020353B4, (u32)dsiSaveOpen);
-		//*(u32*)0x020355D8 = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x020355DC = 0xE12FFF1E; // bx lr
+		// *(u32*)0x020355D8 = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x020355DC = 0xE12FFF1E; // bx lr
 		setBL(0x02035608, (u32)dsiSaveOpen);
 		setBL(0x02035658, (u32)dsiSaveRead);
 		setBL(0x0203569C, (u32)dsiSaveClose);
-		//*(u32*)0x020356C4 = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x020356C8 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x020356C4 = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x020356C8 = 0xE12FFF1E; // bx lr
 		setBL(0x020356E8, (u32)dsiSaveCreate);
 		setBL(0x020356F8, (u32)dsiSaveGetResultCode);
 		setBL(0x0203571C, (u32)dsiSaveOpen);
@@ -1015,13 +1015,13 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 	// Art Style: BOXLIFE (Europe, Australia)
 	else if (strcmp(romTid, "KAHV") == 0 && saveOnFlashcard) {
 		setBL(0x02034FFC, (u32)dsiSaveOpen);
-		//*(u32*)0x02035220 = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x02035224 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x02035220 = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x02035224 = 0xE12FFF1E; // bx lr
 		setBL(0x02035250, (u32)dsiSaveOpen);
 		setBL(0x020352A0, (u32)dsiSaveRead);
 		setBL(0x020352E4, (u32)dsiSaveClose);
-		//*(u32*)0x0203530C = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x02035310 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0203530C = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x02035310 = 0xE12FFF1E; // bx lr
 		setBL(0x02035330, (u32)dsiSaveCreate);
 		setBL(0x02035340, (u32)dsiSaveGetResultCode);
 		setBL(0x02035364, (u32)dsiSaveOpen);
@@ -1033,13 +1033,13 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 	// Art Style: Hacolife (Japan)
 	else if (strcmp(romTid, "KAHJ") == 0 && saveOnFlashcard) {
 		setBL(0x02034348, (u32)dsiSaveOpen);
-		//*(u32*)0x0203456C = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x02034570 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0203456C = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x02034570 = 0xE12FFF1E; // bx lr
 		setBL(0x0203459C, (u32)dsiSaveOpen);
 		setBL(0x020345EC, (u32)dsiSaveRead);
 		setBL(0x02034630, (u32)dsiSaveClose);
-		//*(u32*)0x02034658 = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x0203465C = 0xE12FFF1E; // bx lr
+		// *(u32*)0x02034658 = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x0203465C = 0xE12FFF1E; // bx lr
 		setBL(0x0203467C, (u32)dsiSaveCreate);
 		setBL(0x0203468C, (u32)dsiSaveGetResultCode);
 		setBL(0x020346B0, (u32)dsiSaveOpen);
@@ -1128,7 +1128,7 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 
 	// Cake Ninja (USA)
 	else if (strcmp(romTid, "K2JE") == 0 && saveOnFlashcard) {
-		//*(u32*)0x02008918 = 0xE12FFF1E; // bx lr (NO$GBA fix)
+		// *(u32*)0x02008918 = 0xE12FFF1E; // bx lr (NO$GBA fix)
 		setBL(0x0202CDF0, (u32)dsiSaveOpen);
 		setBL(0x0202CE48, (u32)dsiSaveCreate);
 		setBL(0x0202CE7C, (u32)dsiSaveOpen);
@@ -1262,9 +1262,9 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 	// Castle Conqueror (USA)
 	else if (strcmp(romTid, "KCNE") == 0 && saveOnFlashcard) {
 		tonccpy((u32*)0x020252B8, dsiSaveGetResultCode, 0xC);
-		//*(u32*)0x0204AFD8 = 0xE12FFF1E; // bx lr
-		//*(u32*)0x0204B084 = 0xE12FFF1E; // bx lr
-		//*(u32*)0x0204B44C = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0204AFD8 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0204B084 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0204B44C = 0xE12FFF1E; // bx lr
 		setBL(0x0204AFF4, (u32)dsiSaveCreate);
 		setBL(0x0204B014, (u32)dsiSaveOpen);
 		setBL(0x0204B040, (u32)dsiSaveCreate);
@@ -1291,11 +1291,11 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 	// Castle Conqueror (Europe)
 	else if (strcmp(romTid, "KCNP") == 0 && saveOnFlashcard) {
 		tonccpy((u32*)0x02016EC4, dsiSaveGetResultCode, 0xC);
-		//*(u32*)0x0203A5A4 = 0xE12FFF1E; // bx lr
-		//*(u32*)0x0203A7D4 = 0xE12FFF1E; // bx lr
-		//*(u32*)0x0203AB6C = 0xE12FFF1E; // bx lr
-		//*(u32*)0x0203B134 = 0xE12FFF1E; // bx lr
-		//*(u32*)0x0203BA14 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0203A5A4 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0203A7D4 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0203AB6C = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0203B134 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0203BA14 = 0xE12FFF1E; // bx lr
 		setBL(0x0203A75C, (u32)dsiSaveOpen);
 		setBL(0x0203A78C, (u32)dsiSaveWrite);
 		setBL(0x0203A7AC, (u32)dsiSaveSeek);
@@ -1514,9 +1514,9 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 
 	// Cave Story (USA)
 	else if (strcmp(romTid, "KCVE") == 0 && saveOnFlashcard) {
-		//*(u32*)0x02005980 = 0xE12FFF1E; // bx lr
-		//*(u32*)0x02005A68 = 0xE12FFF1E; // bx lr
-		//*(u32*)0x02005B60 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x02005980 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x02005A68 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x02005B60 = 0xE12FFF1E; // bx lr
 		setBL(0x02005994, (u32)dsiSaveCreate);
 		setBL(0x020059D0, (u32)dsiSaveOpen);
 		setBL(0x02005A28, (u32)dsiSaveWrite);
@@ -1800,7 +1800,7 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 	// GO Series: Defence Wars (Europe)
 	else if ((strcmp(romTid, "KWTE") == 0 || strcmp(romTid, "KWTP") == 0) && saveOnFlashcard) {
 		*(u32*)0x0200B350 = 0xE1A00000; // nop (Disable NFTR loading from TWLNAND)
-		//*(u32*)0x0200C584 = 0xE1A00000; // nop
+		// *(u32*)0x0200C584 = 0xE1A00000; // nop
 		setBL(0x0200C5C0, (u32)dsiSaveCreate);
 		setBL(0x0200C5FC, (u32)dsiSaveOpen);
 		setBL(0x0200C634, (u32)dsiSaveSetLength);
@@ -1833,10 +1833,10 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		*(u32*)0x020248C4 = 0xE12FFF1E; // bx lr (Skip NFTR font rendering)
 		*(u32*)0x02025CD4 = 0xE12FFF1E; // bx lr (Skip NFTR font rendering)
 		*(u32*)0x0203D228 = 0xE3A00000; // mov r0, #0 (Skip saving to "back.dat")
-		//*(u32*)0x0203D488 = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x0203D48C = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0203D488 = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x0203D48C = 0xE12FFF1E; // bx lr
 		if (ndsHeader->gameCode[3] == 'E') {
-			//*(u32*)0x02044B00 = 0xE3A00000; // mov r0, #0
+			// *(u32*)0x02044B00 = 0xE3A00000; // mov r0, #0
 			setBL(0x020590C0, (u32)dsiSaveCreate);
 			setBL(0x02059270, (u32)dsiSaveOpen);
 			setBL(0x020593CC, (u32)dsiSaveClose);
@@ -1851,7 +1851,7 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 			*(u32*)0x020736DC = 0xE12FFF1E; // bx lr (Skip NFTR font rendering)
 			*(u32*)0x02074054 = 0xE1A00000; // nop (Skip NFTR file loading from TWLNAND)
 		} else {
-			//*(u32*)0x02044A9C = 0xE3A00000; // mov r0, #0
+			// *(u32*)0x02044A9C = 0xE3A00000; // mov r0, #0
 			setBL(0x02058FB0, (u32)dsiSaveCreate);
 			setBL(0x02059160, (u32)dsiSaveOpen);
 			setBL(0x020592BC, (u32)dsiSaveClose);
@@ -1877,9 +1877,9 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		*(u32*)0x0202D644 = 0xE12FFF1E; // bx lr (Skip NFTR font rendering)
 		*(u32*)0x0202DFF0 = 0xE1A00000; // nop (Skip NFTR file loading from TWLNAND)
 		*(u32*)0x0205824C = 0xE3A00000; // mov r0, #0 (Skip saving to "back.dat")
-		//*(u32*)0x020584B4 = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x020584B8 = 0xE12FFF1E; // bx lr
-		//*(u32*)0x0205F6F0 = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x020584B4 = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x020584B8 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0205F6F0 = 0xE3A00000; // mov r0, #0
 		setBL(0x020736C4, (u32)dsiSaveCreate);
 		setBL(0x02073874, (u32)dsiSaveOpen);
 		setBL(0x020739D0, (u32)dsiSaveClose);
@@ -2020,9 +2020,9 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 	// GO Series: Earth Saver (USA)
 	else if (strcmp(romTid, "KB8E") == 0 && saveOnFlashcard) {
 		*(u32*)0x02005530 = 0xE1A00000; // nop
-		//*(u32*)0x02005534 = 0xE1A00000; // nop
+		// *(u32*)0x02005534 = 0xE1A00000; // nop
 		*(u32*)0x0200A3D8 = 0xE1A00000; // nop (Disable NFTR loading from TWLNAND)
-		//*(u32*)0x0200A898 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0200A898 = 0xE12FFF1E; // bx lr
 		setBL(0x0200AC14, (u32)dsiSaveOpen);
 		setBL(0x0200AC50, (u32)dsiSaveRead);
 		setBL(0x0200AC70, (u32)dsiSaveClose);
@@ -2139,10 +2139,10 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		setBLThumb(0x02028220, dsiSaveReadT); // dsiSaveReadAsync
 		doubleNopT(0x02028230); // dsiSaveFlush
 		setBLThumb(0x02028236, dsiSaveCloseT); */
-		//*(u16*)0x0203728C = 0x2000; // movs r0, #0 (dsiSaveOpenDir)
-		//*(u16*)0x0203728E = 0x4770; // bx lr
-		//*(u16*)0x020372D8 = 0x2000; // movs r0, #0 (dsiSaveCloseDir)
-		//*(u16*)0x020372DA = 0x4770; // bx lr
+		// *(u16*)0x0203728C = 0x2000; // movs r0, #0 (dsiSaveOpenDir)
+		// *(u16*)0x0203728E = 0x4770; // bx lr
+		// *(u16*)0x020372D8 = 0x2000; // movs r0, #0 (dsiSaveCloseDir)
+		// *(u16*)0x020372DA = 0x4770; // bx lr
 	}
 
 	// Frogger Returns (USA)
@@ -2756,7 +2756,7 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		setBL(0x0200B048, (u32)dsiSaveCreate);
 		setBL(0x0200B070, (u32)dsiSaveGetResultCode);
 		setBL(0x0200B090, (u32)dsiSaveCreate);
-		//*(u32*)0x0200B0A0 = 0xE1A00000; // nop
+		// *(u32*)0x0200B0A0 = 0xE1A00000; // nop
 		setBL(0x0200B0E8, (u32)dsiSaveOpen);
 		setBL(0x0200B114, (u32)dsiSaveOpen);
 		setBL(0x0200B124, (u32)dsiSaveRead);
@@ -2786,7 +2786,7 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		setBL(0x0200B350, (u32)dsiSaveCreate);
 		setBL(0x0200B378, (u32)dsiSaveGetResultCode);
 		setBL(0x0200B398, (u32)dsiSaveCreate);
-		//*(u32*)0x0200B3A8 = 0xE1A00000; // nop
+		// *(u32*)0x0200B3A8 = 0xE1A00000; // nop
 		setBL(0x0200B3F0, (u32)dsiSaveOpen);
 		setBL(0x0200B41C, (u32)dsiSaveOpen);
 		setBL(0x0200B42C, (u32)dsiSaveRead);
@@ -2816,7 +2816,7 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		setBL(0x0200B134, (u32)dsiSaveCreate);
 		setBL(0x0200B158, (u32)dsiSaveGetResultCode);
 		setBL(0x0200B174, (u32)dsiSaveCreate);
-		//*(u32*)0x0200B184 = 0xE1A00000; // nop
+		// *(u32*)0x0200B184 = 0xE1A00000; // nop
 		setBL(0x0200B1D4, (u32)dsiSaveOpen);
 		setBL(0x0200B1FC, (u32)dsiSaveOpen);
 		setBL(0x0200B210, (u32)dsiSaveRead);
@@ -2846,7 +2846,7 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		setBL(0x0200547C, (u32)dsiSaveCreate);
 		setBL(0x020054A0, (u32)dsiSaveGetResultCode);
 		setBL(0x020054BC, (u32)dsiSaveCreate);
-		//*(u32*)0x020054E4 = 0xE1A00000; // nop
+		// *(u32*)0x020054E4 = 0xE1A00000; // nop
 		setBL(0x02005534, (u32)dsiSaveOpen);
 		setBL(0x0200555C, (u32)dsiSaveOpen);
 		setBL(0x02005570, (u32)dsiSaveRead);
@@ -2908,7 +2908,7 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		*(u32*)0x0207F63C = 0xE3A00001; // mov r0, #1
 		*(u32*)0x0207F640 = 0xE12FFF1E; // bx lr */
 		*(u32*)0x0207F0B8 = 0xE3A00001; // mov r0, #1
-		//*(u32*)0x0207F17C = 0xE3A00001; // mov r0, #1 (dsiSaveFreeSpaceAvailable)
+		// *(u32*)0x0207F17C = 0xE3A00001; // mov r0, #1 (dsiSaveFreeSpaceAvailable)
 		setBL(0x0207F244, (u32)dsiSaveCreate);
 		setBL(0x0207F254, (u32)dsiSaveOpen);
 		setBL(0x0207F298, (u32)dsiSaveSetLength);
@@ -2936,7 +2936,7 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		*(u32*)0x0207F558 = 0xE3A00001; // mov r0, #1
 		*(u32*)0x0207F55C = 0xE12FFF1E; // bx lr */
 		*(u32*)0x0207EFC4 = 0xE3A00001; // mov r0, #1
-		//*(u32*)0x0207F084 = 0xE3A00001; // mov r0, #1 (dsiSaveFreeSpaceAvailable)
+		// *(u32*)0x0207F084 = 0xE3A00001; // mov r0, #1 (dsiSaveFreeSpaceAvailable)
 		setBL(0x0207F14C, (u32)dsiSaveCreate);
 		setBL(0x0207F15C, (u32)dsiSaveOpen);
 		setBL(0x0207F1A0, (u32)dsiSaveSetLength);
@@ -3230,7 +3230,7 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 
 	// Paul's Shooting Adventure (USA)
 	else if (strcmp(romTid, "KPJE") == 0 && saveOnFlashcard) {
-		//*(u32*)0x0203A20C = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0203A20C = 0xE12FFF1E; // bx lr
 		setBL(0x02048524, (u32)dsiSaveOpen);
 		setBL(0x0204853C, (u32)dsiSaveCreate);
 		setBL(0x02048554, (u32)dsiSaveOpen);
@@ -3267,7 +3267,7 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		setBL(0x0202F08C, (u32)dsiSaveCreate); // dsiSaveCreateAuto
 		setBL(0x0202F09C, (u32)dsiSaveOpen);
 		setBL(0x0202F0C8, (u32)dsiSaveClose);
-		//*(u32*)0x0203A730 = 0xE3A00001; // mov r0, #1
+		// *(u32*)0x0203A730 = 0xE3A00001; // mov r0, #1
 	}
 
 	// Peg Solitaire (USA)
@@ -3436,8 +3436,8 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		setBL(0x020058E8, (u32)dsiSaveOpen);
 		setBL(0x02005928, (u32)dsiSaveRead);
 		setBL(0x0200595C, (u32)dsiSaveClose);
-		//*(u32*)0x020059E4 = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x020059E8 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x020059E4 = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x020059E8 = 0xE12FFF1E; // bx lr
 		setBL(0x02005A18, (u32)dsiSaveCreate);
 		setBL(0x02005A28, (u32)dsiSaveGetResultCode);
 		setBL(0x02005A4C, (u32)dsiSaveOpen);
@@ -3452,8 +3452,8 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		setBL(0x02005968, (u32)dsiSaveOpen);
 		setBL(0x020059B0, (u32)dsiSaveRead);
 		setBL(0x020059F4, (u32)dsiSaveClose);
-		//*(u32*)0x02005A8C = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x02005A90 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x02005A8C = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x02005A90 = 0xE12FFF1E; // bx lr
 		setBL(0x02005ABC, (u32)dsiSaveCreate);
 		setBL(0x02005ACC, (u32)dsiSaveGetResultCode);
 		setBL(0x02005AE8, (u32)dsiSaveOpen);
@@ -3641,7 +3641,7 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		setBL(0x02099390, (u32)dsiSaveClose);
 		*(u32*)0x020993C8 = 0xE1A00000; // nop (dsiSaveCreateDirAuto)
 		setBL(0x020993D4, (u32)dsiSaveCreate);
-		//*(u32*)0x020C2F94 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x020C2F94 = 0xE12FFF1E; // bx lr
 		tonccpy((u32*)0x020F8B24, dsiSaveGetResultCode, 0xC);
 	}
 
@@ -3657,7 +3657,7 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		setBL(0x02099BFC, (u32)dsiSaveClose);
 		*(u32*)0x02099C34 = 0xE1A00000; // nop (dsiSaveCreateDirAuto)
 		setBL(0x02099C40, (u32)dsiSaveCreate);
-		//*(u32*)0x020C41F8 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x020C41F8 = 0xE12FFF1E; // bx lr
 		tonccpy((u32*)0x020FA794, dsiSaveGetResultCode, 0xC);
 	}
 
@@ -3698,8 +3698,8 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		setBL(0x02007668, (u32)dsiSaveOpen);
 		setBL(0x020076AC, (u32)dsiSaveRead);
 		setBL(0x020076E0, (u32)dsiSaveClose);
-		//*(u32*)0x02007768 = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x0200776C = 0xE12FFF1E; // bx lr
+		// *(u32*)0x02007768 = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x0200776C = 0xE12FFF1E; // bx lr
 		setBL(0x0200779C, (u32)dsiSaveCreate);
 		setBL(0x020077AC, (u32)dsiSaveGetResultCode);
 		setBL(0x020077CC, (u32)dsiSaveOpen);
@@ -3890,7 +3890,7 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 	// Quick Fill Q (Europe)
 	// A bit hard/confusing to add save support
 	else if ((strcmp(romTid, "KUME") == 0 || strcmp(romTid, "KUMP") == 0) && saveOnFlashcard) {
-		//*(u32*)0x0203EA70 = 0xE3A00001; // mov r0, #1 (dsiSaveGetArcSrc)
+		// *(u32*)0x0203EA70 = 0xE3A00001; // mov r0, #1 (dsiSaveGetArcSrc)
 		*(u32*)0x02040240 = 0xE1A00000; // nop (Skip Manual screen)
 	}
 
@@ -4537,8 +4537,8 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 	// Simple DS Series Vol. 1: The Misshitsukara no Dasshutsu (Japan)
 	else if (strcmp(romTid, "KM4J") == 0 && saveOnFlashcard) {
 		*(u32*)0x0200F91C = 0xE1A00000; // nop (Disable NFTR loading from TWLNAND)
-		//*(u32*)0x020128BC = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x020128C0 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x020128BC = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x020128C0 = 0xE12FFF1E; // bx lr
 		setBL(0x020132D0, (u32)dsiSaveOpen);
 		setBL(0x02013338, (u32)dsiSaveCreate); // dsiSaveCreateAuto
 		setBL(0x02013384, (u32)dsiSaveGetLength);
@@ -4832,8 +4832,8 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 
 	// Sudoku (Europe, Australia) (Rev 1)
 	else if (strcmp(romTid, "K4DV") == 0 && saveOnFlashcard) {
-		//*(u32*)0x020360E8 = 0xE3A00001; // mov r0, #1
-		//*(u32*)0x020360EC = 0xE12FFF1E; // bx lr
+		// *(u32*)0x020360E8 = 0xE3A00001; // mov r0, #1
+		// *(u32*)0x020360EC = 0xE12FFF1E; // bx lr
 		setBL(0x020375AC, (u32)dsiSaveOpen);
 		*(u32*)0x020375CC = 0xE1A00000; // nop
 		setBL(0x020375FC, (u32)dsiSaveCreate);
@@ -4999,13 +4999,13 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		setBL(0x0205A778, (u32)dsiSaveGetLength);
 		setBL(0x0205A7B0, (u32)dsiSaveRead);
 		setBL(0x0205A7CC, (u32)dsiSaveClose);
-		//*(u32*)0x0205A83C = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0205A83C = 0xE12FFF1E; // bx lr
 		setBL(0x0205A864, (u32)dsiSaveCreate);
 		setBL(0x0205A874, (u32)dsiSaveGetResultCode);
 		setBL(0x0205A89C, (u32)dsiSaveOpen);
 		setBL(0x0205A8C0, (u32)dsiSaveWrite);
 		setBL(0x0205A8F0, (u32)dsiSaveClose);
-		//*(u32*)0x0205A92C = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0205A92C = 0xE12FFF1E; // bx lr
 		setBL(0x0205A95C, (u32)dsiSaveOpen);
 		setBL(0x0205A99C, (u32)dsiSaveSeek);
 		setBL(0x0205A9DC, (u32)dsiSaveWrite);
@@ -5021,13 +5021,13 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		setBL(0x0205A764, (u32)dsiSaveGetLength);
 		setBL(0x0205A79C, (u32)dsiSaveRead);
 		setBL(0x0205A7B8, (u32)dsiSaveClose);
-		//*(u32*)0x0205A828 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0205A828 = 0xE12FFF1E; // bx lr
 		setBL(0x0205A850, (u32)dsiSaveCreate);
 		setBL(0x0205A860, (u32)dsiSaveGetResultCode);
 		setBL(0x0205A888, (u32)dsiSaveOpen);
 		setBL(0x0205A8AC, (u32)dsiSaveWrite);
 		setBL(0x0205A8DC, (u32)dsiSaveClose);
-		//*(u32*)0x0205A918 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0205A918 = 0xE12FFF1E; // bx lr
 		setBL(0x0205A948, (u32)dsiSaveOpen);
 		setBL(0x0205A988, (u32)dsiSaveSeek);
 		setBL(0x0205A9C8, (u32)dsiSaveWrite);
@@ -5060,7 +5060,7 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 	// True Swing Golf Express (USA)
 	// A Little Bit of... Nintendo Touch Golf (Europe, Australia)
 	if ((strcmp(romTid, "K72E") == 0 || strcmp(romTid, "K72V") == 0) && saveOnFlashcard) {
-		//*(u32*)0x02009A84 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x02009A84 = 0xE12FFF1E; // bx lr
 		setBL(0x02009AC0, (u32)dsiSaveOpen);
 		setBL(0x02009AE0, (u32)dsiSaveGetLength);
 		setBL(0x02009B48, (u32)dsiSaveClose);
@@ -5098,7 +5098,7 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 	// Unable to read saved data
 	else if (strcmp(romTid, "K6PJ") == 0 && saveOnFlashcard) {
 		*(u32*)0x02006E84 = 0xE12FFF1E; // bx lr (Skip NFTR font rendering)
-		//*(u32*)0x02007344 = 0xE1A00000; // nop (Skip directory browse)
+		// *(u32*)0x02007344 = 0xE1A00000; // nop (Skip directory browse)
 		*(u32*)0x020092D4 = 0xE3A00000; // mov r0, #0 (Disable NFTR loading from TWLNAND)
 		for (int i = 0; i < 11; i++) { // Skip Manual screen
 			u32* offset = (u32*)0x0200A608;
@@ -5336,8 +5336,8 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		setBL(0x0200EA8C, (u32)dsiSaveOpen);
 		setBL(0x0200EAE4, (u32)dsiSaveRead);
 		setBL(0x0200EB28, (u32)dsiSaveClose);
-		//*(u32*)0x0200EBC8 = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x0200EBCC = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0200EBC8 = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x0200EBCC = 0xE12FFF1E; // bx lr
 		setBL(0x0200EBF4, (u32)dsiSaveCreate);
 		setBL(0x0200EC04, (u32)dsiSaveGetResultCode);
 		setBL(0x0200EC28, (u32)dsiSaveOpen);
@@ -5352,8 +5352,8 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		setBL(0x0200ED4C, (u32)dsiSaveOpen);
 		setBL(0x0200EDA0, (u32)dsiSaveRead);
 		setBL(0x0200EDF0, (u32)dsiSaveClose);
-		//*(u32*)0x0200EE98 = 0xE3A00000; // mov r0, #0
-		//*(u32*)0x0200EE9C = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0200EE98 = 0xE3A00000; // mov r0, #0
+		// *(u32*)0x0200EE9C = 0xE12FFF1E; // bx lr
 		setBL(0x0200EEC0, (u32)dsiSaveCreate);
 		setBL(0x0200EED0, (u32)dsiSaveGetResultCode);
 		setBL(0x0200EEEC, (u32)dsiSaveOpen);
@@ -5478,7 +5478,7 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 		*(u32*)0x020142B8 = 0xE1A00000; // nop (dsiSaveCreateDirAuto)
 		setBL(0x020142C4, (u32)dsiSaveCreate);
 		tonccpy((u32*)0x02016E10, dsiSaveGetResultCode, 0xC);
-		//*(u32*)0x020815F8 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x020815F8 = 0xE12FFF1E; // bx lr
 	}
 
 	else if (dsiSD) {
@@ -5586,13 +5586,13 @@ void dsiWarePatch(cardengineArm9* ce9, const tNDSHeader* ndsHeader) {
 	// Face Pilot: Fly With Your Nintendo DSi Camera! (USA)
 	else if (strcmp(romTid, "KYBE") == 0) {
 		*(u32*)0x0200BB54 = 0xE12FFF1E; // bx lr
-		//*(u32*)0x0203C928 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0203C928 = 0xE12FFF1E; // bx lr
 	}
 
 	// Face Pilot: Fly With Your Nintendo DSi Camera! (Europe, Australia)
 	else if (strcmp(romTid, "KYBV") == 0) {
 		*(u32*)0x0200BB44 = 0xE12FFF1E; // bx lr
-		//*(u32*)0x0203C9E4 = 0xE12FFF1E; // bx lr
+		// *(u32*)0x0203C9E4 = 0xE12FFF1E; // bx lr
 	}
 
 	// Ferrari GT: Evolution (USA)
@@ -5769,16 +5769,16 @@ void patchBinary(cardengineArm9* ce9, const tNDSHeader* ndsHeader, module_params
 
 	const char* romTid = getRomTid(ndsHeader);
 
-	const u32* dsiSaveGetResultCode = ce9->patches->dsiSaveGetResultCode;
+	// const u32* dsiSaveGetResultCode = ce9->patches->dsiSaveGetResultCode;
 	const u32* dsiSaveCreate = ce9->patches->dsiSaveCreate;
-	const u32* dsiSaveDelete = ce9->patches->dsiSaveDelete;
-	const u32* dsiSaveGetInfo = ce9->patches->dsiSaveGetInfo;
-	const u32* dsiSaveSetLength = ce9->patches->dsiSaveSetLength;
+	// const u32* dsiSaveDelete = ce9->patches->dsiSaveDelete;
+	// const u32* dsiSaveGetInfo = ce9->patches->dsiSaveGetInfo;
+	// const u32* dsiSaveSetLength = ce9->patches->dsiSaveSetLength;
 	const u32* dsiSaveOpen = ce9->patches->dsiSaveOpen;
-	const u32* dsiSaveOpenR = ce9->patches->dsiSaveOpenR;
+	// const u32* dsiSaveOpenR = ce9->patches->dsiSaveOpenR;
 	const u32* dsiSaveClose = ce9->patches->dsiSaveClose;
-	const u32* dsiSaveGetLength = ce9->patches->dsiSaveGetLength;
-	const u32* dsiSaveSeek = ce9->patches->dsiSaveSeek;
+	// const u32* dsiSaveGetLength = ce9->patches->dsiSaveGetLength;
+	// const u32* dsiSaveSeek = ce9->patches->dsiSaveSeek;
 	const u32* dsiSaveRead = ce9->patches->dsiSaveRead;
 	const u32* dsiSaveWrite = ce9->patches->dsiSaveWrite;
 
@@ -6027,13 +6027,13 @@ void patchBinary(cardengineArm9* ce9, const tNDSHeader* ndsHeader, module_params
 
     // Pokemon Dash (Japan)
 	//else if (strcmp(romTid, "APDJ") == 0) {
-		//*(u32*)0x0206AE70 = 0xE3A00000; //mov r0, #0
-        //*(u32*)0x0206D2C4 = 0xE3A00001; //mov r0, #1
-		//*(u32*)0x0206AE74 = 0xe12fff1e; //bx lr
+		// *(u32*)0x0206AE70 = 0xE3A00000; //mov r0, #0
+        // *(u32*)0x0206D2C4 = 0xE3A00001; //mov r0, #1
+		// *(u32*)0x0206AE74 = 0xe12fff1e; //bx lr
 
-        //*(u32*)0x02000B94 = 0xE1A00000; //nop
+        // *(u32*)0x02000B94 = 0xE1A00000; //nop
 
-		//*(u32*)0x020D5010 = 0xe12fff1e; //bx lr
+		// *(u32*)0x020D5010 = 0xe12fff1e; //bx lr
 	//}
 
     // Pokemon Dash
@@ -6083,13 +6083,13 @@ void patchBinary(cardengineArm9* ce9, const tNDSHeader* ndsHeader, module_params
             *(((u8*)0x0206D2C4)+i) = pdash_patch_chars[i];    
         }*/
 
-        //*((u32*)0x02000BB0) = 0xE1A00000; //nop 
+        // *((u32*)0x02000BB0) = 0xE1A00000; //nop 
 
-		//*(u32*)0x0206D2C4 = 0xE3A00000; //mov r0, #0
-        //*(u32*)0x0206D2C4 = 0xE3A00001; //mov r0, #1
-		//*(u32*)0x0206D2C8 = 0xe12fff1e; //bx lr
+		// *(u32*)0x0206D2C4 = 0xE3A00000; //mov r0, #0
+        // *(u32*)0x0206D2C4 = 0xE3A00001; //mov r0, #1
+		// *(u32*)0x0206D2C8 = 0xe12fff1e; //bx lr
 
-		//*(u32*)0x020D5010 = 0xe12fff1e; //bx lr
+		// *(u32*)0x020D5010 = 0xe12fff1e; //bx lr
 	//}
 
     /* // Pokemon Dash (Kiosk Demo)

--- a/retail/cardengine/arm7/source/clock.c
+++ b/retail/cardengine/arm7/source/clock.c
@@ -24,13 +24,8 @@
 
 ---------------------------------------------------------------------------------*/
 
-#include <nds/bios.h>
 #include <nds/arm7/clock.h>
-#include <nds/interrupts.h>
-#include <nds/ipc.h>
-#include <nds/system.h>
-
-#include <time.h>
+#include <nds/ndstypes.h>
 
 
 
@@ -53,18 +48,6 @@ void BCDToInteger(uint8 * data, uint32 length) {
 	u32 i;
 	for (i = 0; i < length; i++) {
 		data[i] = (data[i] & 0xF) + ((data[i] & 0xF0)>>4)*10;
-	}
-}
-
-
-//---------------------------------------------------------------------------------
-void integerToBCD(uint8 * data, uint32 length) {
-//---------------------------------------------------------------------------------
-	u32 i;
-	for (i = 0; i < length; i++) {
-		int high, low;
-		swiDivMod(data[i], 10, &high, &low);
-		data[i] = (high<<4) | low;
 	}
 }
 
@@ -147,40 +130,3 @@ void rtcGetTimeAndDate(uint8 * time) {
 	}
 	BCDToInteger(time,7);
 }
-
-//---------------------------------------------------------------------------------
-void rtcGetTime(uint8 * time) {
-//---------------------------------------------------------------------------------
-	uint8 command, status;
-
-	command = READ_TIME;
-	rtcTransaction(&command, 1, time, 3);
-
-	command = READ_STATUS_REG1;
-	rtcTransaction(&command, 1, &status, 1);
-	if ( status & STATUS_24HRS ) {
-		time[0] &= 0x3f;
-	} else {
-
-	}
-	BCDToInteger(time,3);
-
-}
-
-/* Nonzero if `y' is a leap year, else zero. */
-#define leap(y) (((y) % 4 == 0 && (y) % 100 != 0) || (y) % 400 == 0)
-
-/* Number of leap years from 1970 to `y' (not including `y' itself). */
-#define nleap(y) (((y) - 1969) / 4 - ((y) - 1901) / 100 + ((y) - 1601) / 400)
-
-/* Additional leapday in February of leap years. */
-#define leapday(m, y) ((m) == 1 && leap (y))
-
-/* Accumulated number of days from 01-Jan up to start of current month. */
-static const short ydays[] = {
-  0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365
-};
-
-/* Length of month `m' (0 .. 11) */
-#define monthlen(m, y) (ydays[(m)+1] - ydays[m] + leapday (m, y))
-

--- a/retail/cardengine/arm9/source/cardengine.c
+++ b/retail/cardengine/arm9/source/cardengine.c
@@ -174,6 +174,7 @@ extern void slot2MpuFix();
 extern void region0Fix(); // Revert region 0 patch
 extern void sdk5MpuFix();
 extern void resetMpu();
+extern u32 getDtcmBase(void);
 
 extern bool dldiPatchBinary (unsigned char *binData, u32 binSize);
 

--- a/retail/cardenginei/arm7/include/patcher/find.h
+++ b/retail/cardenginei/arm7/include/patcher/find.h
@@ -55,7 +55,7 @@ u32* findMpuDataOffsetAlt(const tNDSHeader* ndsHeader);
 u32* findHeapPointerOffset(const module_params_t* moduleParams, const tNDSHeader* ndsHeader);
 u32* findHeapPointer2Offset(const module_params_t* moduleParams, const tNDSHeader* ndsHeader);
 u32* findRandomPatchOffset(const tNDSHeader* ndsHeader);
-u32* findSleepOffset(const tNDSHeader* ndsHeader, const module_params_t* moduleParams, bool usesThumb, u32* usesThumbPtr);
+u32* findSleepOffset(const tNDSHeader* ndsHeader, const module_params_t* moduleParams, bool usesThumb, bool* usesThumbPtr);
 u32* findCardEndReadDma(const tNDSHeader* ndsHeader, const module_params_t* moduleParams, bool usesThumb, const u32* cardReadDmaEndOffset, u32* offsetDmaHandler);
 u32* findCardSetDma(const tNDSHeader* ndsHeader, const module_params_t* moduleParams, bool usesThumb);
 u32* findResetOffset(const tNDSHeader* ndsHeader, const module_params_t* moduleParams, bool* softResetMb);

--- a/retail/cardenginei/arm7/source/cardengine.c
+++ b/retail/cardenginei/arm7/source/cardengine.c
@@ -1045,9 +1045,9 @@ static bool nandRead(void) {
 	u32 flash = *(vu32*)(sharedAddr+2);
 	u32 memory = *(vu32*)(sharedAddr);
 	u32 len = *(vu32*)(sharedAddr+1);
+	#ifdef DEBUG
 	u32 marker = *(vu32*)(sharedAddr+3);
 
-	#ifdef DEBUG
 	dbg_printf("\nnand read received\n");
 
 	if (calledViaIPC) {
@@ -1065,7 +1065,7 @@ static bool nandRead(void) {
 
 	//driveInitialize();
 	//cardReadLED(true, true);    // When a file is loading, turn on LED for card read indicator
-	return fileRead(memory, *savFile, flash, len, -1);
+	return fileRead((char *)memory, *savFile, flash, len, -1);
 	//cardReadLED(false, true);
 }
 
@@ -1073,9 +1073,9 @@ static bool nandWrite(void) {
 	u32 flash = *(vu32*)(sharedAddr+2);
 	u32 memory = *(vu32*)(sharedAddr);
 	u32 len = *(vu32*)(sharedAddr+1);
+	#ifdef DEBUG
 	u32 marker = *(vu32*)(sharedAddr+3);
 
-	#ifdef DEBUG
 	dbg_printf("\nnand write received\n");
 
 	if (calledViaIPC) {
@@ -1094,7 +1094,7 @@ static bool nandWrite(void) {
 	//driveInitialize();
 	saveTimer = 1;			// When we're saving, power button does nothing, in order to prevent corruption.
 	//cardReadLED(true, true);    // When a file is loading, turn on LED for card read indicator
-	return fileWrite(memory, *savFile, flash, len, -1);
+	return fileWrite((char *)memory, *savFile, flash, len, -1);
 	//cardReadLED(false, true);
 }
 

--- a/retail/cardenginei/arm7/source/clock.c
+++ b/retail/cardenginei/arm7/source/clock.c
@@ -24,13 +24,8 @@
 
 ---------------------------------------------------------------------------------*/
 
-#include <nds/bios.h>
 #include <nds/arm7/clock.h>
-#include <nds/interrupts.h>
-#include <nds/ipc.h>
-#include <nds/system.h>
-
-#include <time.h>
+#include <nds/ndstypes.h>
 
 
 
@@ -53,18 +48,6 @@ void BCDToInteger(uint8 * data, uint32 length) {
 	u32 i;
 	for (i = 0; i < length; i++) {
 		data[i] = (data[i] & 0xF) + ((data[i] & 0xF0)>>4)*10;
-	}
-}
-
-
-//---------------------------------------------------------------------------------
-void integerToBCD(uint8 * data, uint32 length) {
-//---------------------------------------------------------------------------------
-	u32 i;
-	for (i = 0; i < length; i++) {
-		int high, low;
-		swiDivMod(data[i], 10, &high, &low);
-		data[i] = (high<<4) | low;
 	}
 }
 
@@ -147,40 +130,3 @@ void rtcGetTimeAndDate(uint8 * time) {
 	}
 	BCDToInteger(time,7);
 }
-
-//---------------------------------------------------------------------------------
-void rtcGetTime(uint8 * time) {
-//---------------------------------------------------------------------------------
-	uint8 command, status;
-
-	command = READ_TIME;
-	rtcTransaction(&command, 1, time, 3);
-
-	command = READ_STATUS_REG1;
-	rtcTransaction(&command, 1, &status, 1);
-	if ( status & STATUS_24HRS ) {
-		time[0] &= 0x3f;
-	} else {
-
-	}
-	BCDToInteger(time,3);
-
-}
-
-/* Nonzero if `y' is a leap year, else zero. */
-#define leap(y) (((y) % 4 == 0 && (y) % 100 != 0) || (y) % 400 == 0)
-
-/* Number of leap years from 1970 to `y' (not including `y' itself). */
-#define nleap(y) (((y) - 1969) / 4 - ((y) - 1901) / 100 + ((y) - 1601) / 400)
-
-/* Additional leapday in February of leap years. */
-#define leapday(m, y) ((m) == 1 && leap (y))
-
-/* Accumulated number of days from 01-Jan up to start of current month. */
-static const short ydays[] = {
-  0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365
-};
-
-/* Length of month `m' (0 .. 11) */
-#define monthlen(m, y) (ydays[(m)+1] - ydays[m] + leapday (m, y))
-

--- a/retail/cardenginei/arm7/source/patcher/find_arm7.c
+++ b/retail/cardenginei/arm7/source/patcher/find_arm7.c
@@ -10,7 +10,7 @@
 static const u32 relocateStartSignature[1] = {0x027FFFFA};
 
 static const u32 nextFunctiontSignature[1] = {0xE92D4000};
-static const u32 relocateValidateSignature[1] = {0x400010C};
+// static const u32 relocateValidateSignature[1] = {0x400010C};
 
 static const u32 swi12Signature[1] = {0x4770DF12}; // LZ77UnCompReadByCallbackWrite16bit
 

--- a/retail/cardenginei/arm7/source/patcher/hook_arm9.c
+++ b/retail/cardenginei/arm7/source/patcher/hook_arm9.c
@@ -101,7 +101,7 @@ static u32* hookInterruptHandler(const u32* start, size_t size) {
     dbg_hexa(tableAddr);
     dbg_printf("\n");*/
     
-	u32 returnAddr = addr[1];
+	// u32 returnAddr = addr[1];
     /*dbg_printf("returnAddr\n");
     dbg_hexa(returnAddr);
     dbg_printf("\n");*/

--- a/retail/cardenginei/arm7_dsiware/source/cardengine.c
+++ b/retail/cardenginei/arm7_dsiware/source/cardengine.c
@@ -323,8 +323,8 @@ void reset(void) {
 	if (consoleModel > 0) {
 		ndmaCopyWordsAsynch(0, (char*)ndsHeader->arm9destination+0xB000000, ndsHeader->arm9destination, *(u32*)0x0DFFE02C);
 		ndmaCopyWordsAsynch(1, (char*)ndsHeader->arm7destination+0xB000000, ndsHeader->arm7destination, *(u32*)0x0DFFE03C);
-		ndmaCopyWordsAsynch(2, (char*)(*(u32*)0x02FFE1C8)+0xB000000, *(u32*)0x02FFE1C8, *(u32*)0x0DFFE1CC);
-		ndmaCopyWordsAsynch(3, (char*)(*(u32*)0x02FFE1D8)+0xB000000, *(u32*)0x02FFE1D8, *(u32*)0x0DFFE1DC);
+		ndmaCopyWordsAsynch(2, (char*)(*(u32*)0x02FFE1C8)+0xB000000, (void*)(*(u32*)0x02FFE1C8), *(u32*)0x0DFFE1CC);
+		ndmaCopyWordsAsynch(3, (char*)(*(u32*)0x02FFE1D8)+0xB000000, (void*)(*(u32*)0x02FFE1D8), *(u32*)0x0DFFE1DC);
 		while (ndmaBusy(0) || ndmaBusy(1) || ndmaBusy(2) || ndmaBusy(3));
 	} else {
 		bakData();

--- a/retail/cardenginei/arm9/source/cardDma.thumb.c
+++ b/retail/cardenginei/arm9/source/cardDma.thumb.c
@@ -59,6 +59,9 @@ extern u32 cacheDescriptor[];
 extern int cacheCounter[];
 extern int accessCounter;
 
+extern void callEndReadDmaThumb(void);
+extern void disableIrqMask(u32 mask);
+
 bool isDma = false;
 bool dmaOn = true;
 bool dmaDirectRead = false;
@@ -70,7 +73,7 @@ void endCardReadDma() {
 	}
 
 	if (ce9->patches->cardEndReadDmaRef) {
-		volatile void (*cardEndReadDmaRef)() = ce9->patches->cardEndReadDmaRef;
+		VoidFn cardEndReadDmaRef = (VoidFn)ce9->patches->cardEndReadDmaRef;
 		(*cardEndReadDmaRef)();
 	} else if (ce9->thumbPatches->cardEndReadDmaRef) {
 		callEndReadDmaThumb();
@@ -218,7 +221,7 @@ void continueCardReadDmaArm9() {
 		}
         dmaReadOnArm9 = false;
 
-        vu32* volatile cardStruct = ce9->cardStruct0;
+        vu32* volatile cardStruct = (vu32*)ce9->cardStruct0;
         //u32	dma = cardStruct[3]; // dma channel
 
 		u32 commandRead=0x025FFB0A;
@@ -355,7 +358,7 @@ void continueCardReadDmaArm7() {
         if(!checkArm7()) return;
         dmaReadOnArm7 = false;
 
-        vu32* volatile cardStruct = ce9->cardStruct0;
+        vu32* volatile cardStruct = (vu32*)ce9->cardStruct0;
 
 		u32 src = ((ce9->valueBits & isSdk5) ? dmaParams[3] : cardStruct[0]);
 		u8* dst = ((ce9->valueBits & isSdk5) ? (u8*)(dmaParams[4]) : (u8*)(cardStruct[1]));
@@ -434,7 +437,7 @@ void cardSetDma(u32 * params) {
 		endCardReadDma();
 	}
 	#else
-	vu32* volatile cardStruct = ce9->cardStruct0;
+	vu32* volatile cardStruct = (vu32*)ce9->cardStruct0;
 
 	if (ce9->valueBits & isSdk5) {
 		dmaParams = params;
@@ -602,7 +605,7 @@ void cardSetDma(u32 * params) {
 	u8* dst = (u8*)params[4];
 	u32 len = params[5];
 	#else
-	vu32* volatile cardStruct = ce9->cardStruct0;
+	vu32* volatile cardStruct = (vu32*)ce9->cardStruct0;
 
 	u32 src = ((ce9->valueBits & isSdk5) ? params[3] : cardStruct[0]);
 	u8* dst = ((ce9->valueBits & isSdk5) ? (u8*)(params[4]) : (u8*)(cardStruct[1]));
@@ -617,7 +620,7 @@ void cardSetDma(u32 * params) {
 extern bool isNotTcm(u32 address, u32 len);
 
 u32 cardReadDma(u32 dma0, u8* dst0, u32 src0, u32 len0) {
-	vu32* volatile cardStruct = ce9->cardStruct0;
+	vu32* volatile cardStruct = (vu32*)ce9->cardStruct0;
 
 	u32 src = ((ce9->valueBits & isSdk5) ? src0 : cardStruct[0]);
 	u8* dst = ((ce9->valueBits & isSdk5) ? dst0 : (u8*)(cardStruct[1]));
@@ -629,7 +632,7 @@ u32 cardReadDma(u32 dma0, u8* dst0, u32 src0, u32 len0) {
         //&& func != NULL
         && len > 0
         && !(((int)dst) & 3)
-        && isNotTcm(dst, len)
+        && isNotTcm((u32)dst, len)
         // check 512 bytes page alignement 
         && !(((int)len) & 511)
         && !(((int)src) & 511)

--- a/retail/cardenginei/arm9/source/misc.c
+++ b/retail/cardenginei/arm9/source/misc.c
@@ -50,6 +50,11 @@ extern tNDSHeader* ndsHeader;
 extern bool flagsSet;
 extern bool igmReset;
 
+extern u32 getDtcmBase(void);
+extern void ndsCodeStart(u32* addr);
+void resetSlots(void);
+void initMBKARM9_dsiMode(void);
+
 void SetBrightness(u8 screen, s8 bright) {
 	u16 mode = 1 << 14;
 
@@ -97,12 +102,12 @@ void hookIPC_SYNC(void) {
 		if (!(ce9->valueBits & isSdk5)) {
 			u32* vblankHandler = ce9->irqTable;
 			ce9->intr_vblank_orig_return = *vblankHandler;
-			*vblankHandler = ce9->patches->vblankHandlerRef;
+			*vblankHandler = (u32)ce9->patches->vblankHandlerRef;
 		}
 		#endif
 		u32* ipcSyncHandler = ce9->irqTable + 16;
 		ce9->intr_ipc_orig_return = *ipcSyncHandler;
-		*ipcSyncHandler = ce9->patches->ipcSyncHandlerRef;
+		*ipcSyncHandler = (u32)ce9->patches->ipcSyncHandlerRef;
 		IPC_SYNC_hooked = true;
     }
 }

--- a/retail/cardenginei/arm9_dsiware/source/cardengine.c
+++ b/retail/cardenginei/arm9_dsiware/source/cardengine.c
@@ -38,6 +38,7 @@
 extern cardengineArm9* volatile ce9;
 
 extern void ndsCodeStart(u32* addr);
+extern u32 getDtcmBase(void);
 
 vu32* volatile sharedAddr = (vu32*)CARDENGINE_SHARED_ADDRESS_SDK5;
 
@@ -73,7 +74,7 @@ static void hookIPC_SYNC(void) {
 	if (!IPC_SYNC_hooked) {
 		u32* ipcSyncHandler = ce9->irqTable + 16;
 		ce9->intr_ipc_orig_return = *ipcSyncHandler;
-		*ipcSyncHandler = ce9->patches->ipcSyncHandlerRef;
+		*ipcSyncHandler = (u32)ce9->patches->ipcSyncHandlerRef;
 		IPC_SYNC_hooked = true;
 	}
 }

--- a/retail/cardenginei/arm9_igm/source/exception.c
+++ b/retail/cardenginei/arm9_igm/source/exception.c
@@ -11,7 +11,7 @@ static const char *registerNames[] = {
 };
 
 static s32 *exceptionRegisters;
-static u32 __itcm_start = 0x01000000; // TODO
+static const u32 __itcm_start = 0;
 
 u32 getCPSR();
 

--- a/retail/cardenginei/arm9_igm/source/inGameMenu.c
+++ b/retail/cardenginei/arm9_igm/source/inGameMenu.c
@@ -134,7 +134,7 @@ static void printTime(void) {
 	u8 hours = (u8)sharedAddr[7];
 	u8 minutes = (u8)sharedAddr[8];
 	printDec(0x20 - 6, 0x18 - timeYpos, hours, 2, FONT_LIGHT_BLUE, false);
-	print(0x20 - 4, 0x18 - timeYpos, ":", FONT_LIGHT_BLUE, false);
+	printChar(0x20 - 4, 0x18 - timeYpos, ':', FONT_LIGHT_BLUE, false);
 	printDec(0x20 - 3, 0x18 - timeYpos, minutes, 2, FONT_LIGHT_BLUE, false);
 }
 
@@ -264,8 +264,7 @@ static void screenshot(void) {
 	}
 
 	#ifdef B4DS
-	volatile u32 (*prepareScreenshot)() = (volatile u32*)ce9->prepareScreenshot;
-	(*prepareScreenshot)();
+	(*ce9->prepareScreenshot)();
 	#else
 	sharedAddr[4] = 0x50505353;
 	while (sharedAddr[4] == 0x50505353) {
@@ -300,8 +299,7 @@ static void screenshot(void) {
 	VRAM_x_CR(vramBank) = vramCr;
 
 	#ifdef B4DS
-	volatile u32 (*saveScreenshot)() = (volatile u32*)ce9->saveScreenshot;
-	(*saveScreenshot)();
+	(*ce9->saveScreenshot)();
 	#else
 	sharedAddr[4] = 0x544F4853;
 	while (sharedAddr[4] == 0x544F4853) {
@@ -322,8 +320,7 @@ static void manual(void) {
 
 	while (1) {
 		#ifdef B4DS
-		volatile u32 (*readManual)(int line) = (volatile u32*)ce9->readManual;
-		(*readManual)(igmText.manualLine);
+		(*ce9->readManual)(igmText.manualLine);
 
 		print(0, 0, (unsigned char *)0x027FF200, FONT_WHITE, false);
 		#else

--- a/retail/cardenginei/arm9_romInRam/source/misc.c
+++ b/retail/cardenginei/arm9_romInRam/source/misc.c
@@ -50,6 +50,9 @@ extern tNDSHeader* ndsHeader;
 extern bool flagsSet;
 extern bool igmReset;
 
+extern u32 getDtcmBase(void);
+extern void ndsCodeStart(u32* addr);
+
 void SetBrightness(u8 screen, s8 bright) {
 	u16 mode = 1 << 14;
 
@@ -96,11 +99,11 @@ void hookIPC_SYNC(void) {
 		if (!(ce9->valueBits & isSdk5)) {
 			u32* vblankHandler = ce9->irqTable;
 			ce9->intr_vblank_orig_return = *vblankHandler;
-			*vblankHandler = ce9->patches->vblankHandlerRef;
+			*vblankHandler = (u32)ce9->patches->vblankHandlerRef;
 		}
         u32* ipcSyncHandler = ce9->irqTable + 16;
 		ce9->intr_ipc_orig_return = *ipcSyncHandler;
-        *ipcSyncHandler = ce9->patches->ipcSyncHandlerRef;
+        *ipcSyncHandler = (u32)ce9->patches->ipcSyncHandlerRef;
         IPC_SYNC_hooked = true;
     }
 }

--- a/retail/common/include/cardengine_header_arm9.h
+++ b/retail/common/include/cardengine_header_arm9.h
@@ -206,9 +206,9 @@ typedef struct cardengineArm9 {
     u32 romLocation;
 	u32 rumbleFrames[2];
 	u32 rumbleForce[2];
-	u32* prepareScreenshot;
-	u32* saveScreenshot;
-	u32* readManual;
+	VoidFn prepareScreenshot;
+	VoidFn saveScreenshot;
+	void (* readManual)(int);
 } __attribute__ ((__packed__)) cardengineArm9;
 #endif
 


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Fixes a ton of warnings, most just by casting properly or defining formerly implicit functions or such; there should be very few actual functionality changes
- The changes with the most potential to have broken something are:
   - bootloaderi/cardenginei -> find_arm9.c:109
   - bootloader -> find_arm9.c:1693 / bootloaderi -> find_arm9.c:2804 / cardenginei -> find_arm9.c:1440
   - ips.c:102-105 (deleted)
- The only warnings left are in the DLDI patching, idk how to fix -Warray-bounds

#### Where have you tested it?

- DSi (K) from Unlaunch

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
