### PR TITLE
Migrate exclude maps to nds-bootstrap

### DIFF
--- a/retail/arm9/Makefile
+++ b/retail/arm9/Makefile
@@ -46,7 +46,7 @@ CFLAGS	:=	-g -Wall -O2\
 			-ffast-math \
 			$(ARCH)
 
-CFLAGS	+=	$(INCLUDE) -DARM9 -DNO_CARDID
+CFLAGS	+=	$(INCLUDE) -DARM9 -DNO_CARDID -DDEFAULT_CARD_READ_DMA
 CXXFLAGS	:=	$(CFLAGS) -fno-rtti -fno-exceptions
 
 ASFLAGS	:=	-g $(ARCH) $(INCLUDE)

--- a/retail/arm9/include/asyncReadExcludeMap.h
+++ b/retail/arm9/include/asyncReadExcludeMap.h
@@ -1,0 +1,72 @@
+#ifndef ASYNCHREADEXCLUDEMAP_H
+#define ASYNCHREADEXCLUDEMAP_H
+
+static const char asyncReadExcludeList[][4] = {
+	"CD6", // 7th Dragon
+	"ADM", // Animal Crossing: Wild World
+	"VAA", // Art Academy
+	"CBB", // Big Bang Mini
+	"CVZ", // Blazer Drive
+	"ABX", // Bomberman Land Touch!
+	"ACB", // Castlevania: Portrait of Ruin
+	"VCW", // Classic Word Games
+	"ADK", // Daikoukai Jidai IV: Rota Nova
+	"YDQ", // Dragon Quest IX: Sentinels of the Starry Skies
+	"DMD", // DSi XL Demo Video Volume 1
+	"DME", // DSi XL Demo Video Volume 2
+	"BJ3", // Etrian Odyssey 3
+	"USK", // Face Training
+	"BGT", // Ghost Trick: Phantom Detective
+	"YEE", // Inazuma Eleven
+	"BEE", // Inazuma Eleven 2: Firestorm
+	"BEB", // Inazuma Eleven 2: Blizzard
+	"BEZ", // Inazuma Eleven 3: Bomb Blast
+	"BE8", // Inazuma Eleven 3: Lightning Bolt
+	"BOE", // Inazuma Eleven 3: Team Ogre Attacks!
+	"YLU", // Last Window: The Secret of Cape West
+	"BSD", // Lufia: Curse of the Sinistrals
+	"AY9", // Mario & Sonic at the Olympic Games
+	"V2G", // Mario vs. Donkey Kong: Mini-Land Mayhem!
+	"YZX", // Rockman ZX Advent/MegaMan ZX Advent
+	"CNS", // Naruto Shippuden: Naruto vs Sasuke
+	"DMP", // NOE Movie Player Volume 1
+	"BKI", // The Legend of Zelda: Spirit Tracks (Keeps AP-fix in effect)
+	"Y7S", // The Legend of Zelda: Spirit Tracks (Demo)
+	"B6F", // LEGO Batman 2: DC Super Heroes
+	"TLJ", // LEGO Friends
+	"BLH", // LEGO Harry Potter: Years 1-4
+	"B83", // LEGO Harry Potter: Years 5-7
+	"BLJ", // LEGO Indiana Jones 2: The Adventure Continues
+	"TCB", // LEGO Legends of Chima: Laval's Journey
+	"TLR", // LEGO The Lord of the Rings
+	"TLM", // LEGO Marvel Super Heroes: Universe in Peril
+	"BVY", // LEGO Ninjago: The Videogame
+	"BZD", // LEGO Pirates of the Caribbean: The Video Game
+	"BL9", // LEGO Star Wars III: The Clone Wars
+	"YL2", // Luminous Arc 2
+	"AWV", // Nervous Brickdown
+	"B2K", // Ni no Kuni: The Jet Black Mage
+	"IRB", // Pokemon Black Version (Keeps AP-fix in effect)
+	"IRA", // Pokemon White Version (Keeps AP-fix in effect)
+	"IRE", // Pokemon Black Version 2 (Keeps AP-fix in effect)
+	"IRD", // Pokemon White Version 2 (Keeps AP-fix in effect)
+	"VPY", // Pokemon Conquest (Keeps AP-fix in effect in DSi mode)
+	"B3R", // Pokemon Ranger: Guardian Signs (Keeps AP-fix in effect)
+	"A5F", // Professor Layton and the Curious Village
+	"Y49", // Professor Layton and the Curious Village (Demo)
+	"YLT", // Professor Layton and the Diabolical/Pandora's Box
+	"Y6Z", // Professor Layton and the Diabolical/Pandora's Box (Demo)
+	"C3J", // Professor Layton and the Unwound/Lost Future
+	"BLF", // Professor Layton and the Last Specter/Spectre's Call
+	"Y9B", // Professor Layton and the Last Specter/Spectre's Call (Demo)
+	"TDV", // Shin Megami Tensei: Devil Survivor 2
+	"BMT", // Shin Megami Tensei: Strange Journey
+	"YSL", // Sands of Destruction
+	"CS3", // Sonic & Sega All-Stars Racing
+	"VSO", // Sonic Classic Collection
+	"AFZ", // Transformers: Autobots
+	"AFY", // Transformers: Decepticons
+	"AYG", // Yu-Gi-Oh! Nightmare Trabadour
+};
+
+#endif // ASYNCHREADEXCLUDEMAP_H

--- a/retail/arm9/include/dmaExcludeMap.h
+++ b/retail/arm9/include/dmaExcludeMap.h
@@ -1,0 +1,17 @@
+#ifndef DMAEXCLUDEMAP_H
+#define DMAEXCLUDEMAP_H
+
+static const char cardReadDMAExcludeList[][4] = {
+	"TAM", // The Amazing Spider-Man
+	"CBX", // Black Sigil: Blade of the Exiled
+	"AWD", // Diddy Kong Racing
+	"BO5", // Golden Sun: Dark Dawn
+	"Y8L", // Golden Sun: Dark Dawn (Demo)
+	"AJS", // Jump! Super Stars
+	"AJU", // Jump! Ultimate Stars
+	"B8I", // Spider-Man: Edge of Time
+	"CTX", // Tropix
+	"CP3", // Viva Pinata
+};
+
+#endif // DMAEXCLUDEMAP_H

--- a/retail/arm9/include/twlClockExcludeMap.h
+++ b/retail/arm9/include/twlClockExcludeMap.h
@@ -1,0 +1,22 @@
+#ifndef TWLCLOCKEXCLUDEMAP_H
+#define TWLCLOCKEXCLUDEMAP_H
+
+static const char twlClockExcludeList[][4] = {
+	"CRL", // Coraline
+	"YGD", // Diary Girl
+	"YGX", // Grand Theft Auto: Chinatown Wars
+	"C6C", // Infinite Space
+	"YJB", // LEGO Batman: The Videogame
+	"BLH", // LEGO Harry Potter: Years 1-4
+	"YLJ", // LEGO Indiana Jones: The Original Adventures
+	"YLG", // LEGO Star Wars: The Complete Saga
+	"AY9", // Mario & Sonic at the Olympic Games
+	"BZP", // Peppa Pig: Theme Park Fun
+	"ARF", // Rune Factory: A Fantasy Harvest Moon
+	"AN6", // Rune Factory 2: A Fantasy Harvest Moon
+	"BRF", // Rune Factory 3: A Fantasy Harvest Moon
+	"ASC", // Sonic Rush
+	"CY8", // Yu-Gi-Oh! 5D's Stardust Accelerator: World Championship 2009
+};
+
+#endif // TWLCLOCKEXCLUDEMAP_H


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

**THIS REQUIRES A CHANGE IN TWILIGHT MENU++ BEFORE MERGING.**

As of commit 4338bafec820baad351b5e565297eaec385c0dee from https://github.com/DS-Homebrew/TWiLightMenu/

As a result, instead of definite values for each of these INI values, one can choose to set an integer other than 0 or 1 to instead let nds-bootstrap handle default settings. Current implementations of these INI parsers will continue to work since stdbool defines 0 as false and 1 as true; however the intent of this commit is to move towards controlling the defaults in nds-bootstrap.

For these maps, the values are now the following:
- case 0 (false): disabled
- case 1 (true): enabled
- else: default nds-bootstrap settings

Default settings can be toggled in the ARM9 makefile by setting `-DDEFAULT_{CARD_READ_DMA,ASYNC_CARD_READ,CPU_BOOST}`. If defined, the checks are run. If not defined, then it just sets it to false.

#### Where have you tested it?

new Nintendo 3DS XL with forwarders built from this PR: https://github.com/RocketRobz/NTR_Forwarder/pull/11


#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
