### PR TITLE
Patch mpu configurations when running off SLOT-2

### DIFF
--- a/retail/cardengine/arm9/source/cardengine.c
+++ b/retail/cardengine/arm9/source/cardengine.c
@@ -189,6 +189,9 @@ void enableIPC_SYNC(void) {
 #endif
 
 extern void slot2MpuFix();
+// fixes mpu protection settings when using a slot2 flashcart
+// to allow running games accessing the slot2 like pokemon
+extern void slot2MpuFixGbaDldi();
 // extern void region0Fix(); // Revert region 0 patch
 extern void sdk5MpuFix();
 extern void resetMpu();
@@ -863,6 +866,7 @@ void cardRead(u32* cacheStruct, u8* dst0, u32 src0, u32 len0) {
 
 	if (__myio_dldi.features & FEATURE_SLOT_GBA) {
 		REG_IE &= ~IRQ_CART;
+		slot2MpuFixGbaDldi();
 	}
 
 	setDeviceOwner();
@@ -1572,6 +1576,10 @@ u32 myIrqEnable(u32 irq) {
 	#ifdef DEBUG
 	nocashMessage("myIrqEnable\n");
 	#endif
+
+	if (__myio_dldi.features & FEATURE_SLOT_GBA) {
+		slot2MpuFixGbaDldi();
+	}
 
 	setDeviceOwner();
 	initialize();

--- a/retail/cardengine/arm9/source/mpuConfig.s
+++ b/retail/cardengine/arm9/source/mpuConfig.s
@@ -1,6 +1,21 @@
 .align	4
 .arm
 
+.global slot2MpuFixGbaDldi
+.type slot2MpuFixGbaDldi, STT_FUNC
+slot2MpuFixGbaDldi:
+    mrc p15, 0, r0, c2, c0, 0
+    bic r0, r0, #(1 << 3)
+    mcr p15, 0, r0, c2, c0, 0
+    mrc p15, 0, r0, c3, c0, 0
+    bic r0, r0, #(1 << 3)
+    mcr p15, 0, r0, c3, c0, 0
+    mrc p15, 0, r0, c5, c0, 2
+    bic r0, r0, #(0xF << 12)
+    orr r0, r0, #(3 << 12)
+    mcr p15, 0, r0, c5, c0, 2
+    bx lr
+
 .global slot2MpuFix
 .type	slot2MpuFix STT_FUNC
 slot2MpuFix:


### PR DESCRIPTION
Change the mpu settings when a SLOT-2 device is being used, fixes issues with games like gen5 pokemon, that block the whole address space beyond 0x08000000 when not in use.
This mpu patching code comes from gericom, and should be reliable to work on all official games
