### PR TITLE
retail: override _io_dldi_stub from libnds

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "retail/libnds32"]
-	path = retail/libnds32
-	url = https://github.com/lifehackerhansol/libnds32
-	branch = master

--- a/retail/Makefile
+++ b/retail/Makefile
@@ -72,7 +72,7 @@ endif
 export GAME_ICON := $(CURDIR)/$(ASSETS)/icon.bmp
 
 #.PHONY: cardengine_arm7 cardengine_arm9 bootloader BootStrap clean
-.PHONY: all dist release nightly bootloader bootloader1 bootloader2 bootloaderi bootloaderi1 bootloaderi2 cardengine_arm7 cardengine_arm7_music cardengine_arm9_igm cardengine_arm9_igm_extmem cardengine_arm9 cardengine_arm9_32 cardengine_arm9_start cardengine_arm9_start_foto cardengine_arm9_alt cardengine_arm9_alt_gsdd cardengine_arm9_alt2 cardengine_arm9_alt3 cardengine_arm9_extmem cardengine_arm9_extmem_gsdd cardengine_arm9_extmem_start cardengine_arm9_extmem_foto cardenginei_arm7 cardenginei_arm7_alt cardenginei_arm7_twlsdk cardenginei_arm7_twlsdk3 cardenginei_arm7_dsiware cardenginei_arm7_dsiware3 cardenginei_arm7_cheat cardenginei_arm9_igm cardenginei_arm9 cardenginei_arm9_sdk20 cardenginei_arm9_dlp cardenginei_arm9_gsdd cardenginei_arm9_dldi cardenginei_arm9_sdk20_dldi cardenginei_arm9_gsdd_dldi cardenginei_arm9_twlsdk cardenginei_arm9_twlsdk3 cardenginei_arm9_twlsdk_dldi cardenginei_arm9_twlsdk3_dldi cardenginei_arm9_dsiware cardenginei_arm9_dsiware3 preLoadSettings apfix libnds32 arm7/$(TARGET).elf arm9/$(TARGET).elf clean
+.PHONY: all dist release nightly bootloader bootloader1 bootloader2 bootloaderi bootloaderi1 bootloaderi2 cardengine_arm7 cardengine_arm7_music cardengine_arm9_igm cardengine_arm9_igm_extmem cardengine_arm9 cardengine_arm9_32 cardengine_arm9_start cardengine_arm9_start_foto cardengine_arm9_alt cardengine_arm9_alt_gsdd cardengine_arm9_alt2 cardengine_arm9_alt3 cardengine_arm9_extmem cardengine_arm9_extmem_gsdd cardengine_arm9_extmem_start cardengine_arm9_extmem_foto cardenginei_arm7 cardenginei_arm7_alt cardenginei_arm7_twlsdk cardenginei_arm7_twlsdk3 cardenginei_arm7_dsiware cardenginei_arm7_dsiware3 cardenginei_arm7_cheat cardenginei_arm9_igm cardenginei_arm9 cardenginei_arm9_sdk20 cardenginei_arm9_dlp cardenginei_arm9_gsdd cardenginei_arm9_dldi cardenginei_arm9_sdk20_dldi cardenginei_arm9_gsdd_dldi cardenginei_arm9_twlsdk cardenginei_arm9_twlsdk3 cardenginei_arm9_twlsdk_dldi cardenginei_arm9_twlsdk3_dldi cardenginei_arm9_dsiware cardenginei_arm9_dsiware3 preLoadSettings apfix arm7/$(TARGET).elf arm9/$(TARGET).elf clean
 
 all:	$(OUTPUT)
 
@@ -101,12 +101,8 @@ arm7/$(TARGET).elf:
 	@$(MAKE) -C arm7
 	
 #---------------------------------------------------------------------------------
-arm9/$(TARGET).elf:	bootloader bootloader1 bootloader2 bootloaderi bootloaderi1 bootloaderi2 preLoadSettings apfix libnds32
+arm9/$(TARGET).elf:	bootloader bootloader1 bootloader2 bootloaderi bootloaderi1 bootloaderi2 preLoadSettings apfix
 	@$(MAKE) -C arm9
-
-#---------------------------------------------------------------------------------		
-libnds32:
-	@$(MAKE) -C libnds32 release
 
 #---------------------------------------------------------------------------------		
 bootloader: cardengine_arm7 cardengine_arm7_music cardengine_arm9_igm cardengine_arm9_igm_extmem cardengine_arm9 cardengine_arm9_32 cardengine_arm9_start cardengine_arm9_start_foto cardengine_arm9_alt cardengine_arm9_alt_gsdd cardengine_arm9_alt2 cardengine_arm9_alt3 cardengine_arm9_extmem cardengine_arm9_extmem_gsdd cardengine_arm9_extmem_start cardengine_arm9_extmem_foto
@@ -297,7 +293,6 @@ apfix:
 clean:
 	@echo clean ...
 	@rm -fr $(BUILD) $(TARGET).elf $(TARGET).nds $(TARGET).nds.orig.nds $(TARGET).arm9 $(BIN)
-	@$(MAKE) -C libnds32 clean
 	@$(MAKE) -C arm7 clean
 	@$(MAKE) -C arm9 clean
 	@$(MAKE) -C cardengine/arm7 clean

--- a/retail/arm9/Makefile
+++ b/retail/arm9/Makefile
@@ -56,14 +56,13 @@ LDFLAGS	=	-specs=../ds_arm9_ndsbs.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 #---------------------------------------------------------------------------------
 # any extra libraries we wish to link with the project (order is important)
 #---------------------------------------------------------------------------------
-LIBS	:=	-lfat -lnds329
+LIBS	:=	-lfat -lnds9
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing
 # include and lib
 #---------------------------------------------------------------------------------
 LIBDIRS	:=	$(LIBNDS)
-LIBDIRS32	:=	$(CURDIR)/../libnds32
 
 #---------------------------------------------------------------------------------
 # no real need to edit anything past this point unless you need to add additional
@@ -105,9 +104,8 @@ export INCLUDE	:=	$(foreach dir,$(INCLUDES),-I$(CURDIR)/$(dir)) \
 					$(foreach dir,$(LIBDIRS),-I$(dir)/include) \
 					-I$(CURDIR)/$(BUILD)
 
-export LIBPATHS	:=	$(foreach dir,$(LIBDIRS),-L$(dir)/lib) \
-					$(foreach dir,$(LIBDIRS32),-L$(dir)/lib)
- 
+export LIBPATHS	:=	$(foreach dir,$(LIBDIRS),-L$(dir)/lib)
+
 .PHONY: $(BUILD) clean
 
 #---------------------------------------------------------------------------------

--- a/retail/arm9/source/my_dldi.s
+++ b/retail/arm9/source/my_dldi.s
@@ -1,0 +1,100 @@
+/*---------------------------------------------------------------------------------
+
+  Copyright (C) 2006 - 2016
+    Michael Chisholm (Chishm)
+    Dave Murphy (WinterMute)
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any
+  damages arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any
+  purpose, including commercial applications, and to alter it and
+  redistribute it freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you
+     must not claim that you wrote the original software. If you use
+     this software in a product, an acknowledgment in the product
+     documentation would be appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and
+     must not be misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source
+     distribution.
+
+---------------------------------------------------------------------------------*/
+
+#include <nds/arm9/dldi_asm.h>
+
+	.align	4
+	.arm
+	.global _io_dldi_stub
+@---------------------------------------------------------------------------------
+
+.equ DLDI_ALLOCATED_SPACE,		32768
+
+_io_dldi_stub:
+
+dldi_start:
+
+@---------------------------------------------------------------------------------
+@ Driver patch file standard header -- 16 bytes
+	.word	0xBF8DA5ED		@ Magic number to identify this region
+	.asciz	" Chishm"		@ Identifying Magic string (8 bytes with null terminator)
+	.byte	0x01			@ Version number
+	.byte	DLDI_SIZE_32KB	@32KiB	@ Log [base-2] of the size of this driver in bytes.
+	.byte	0x00			@ Sections to fix
+	.byte 	DLDI_SIZE_32KB	@32KiB	@ Log [base-2] of the allocated space in bytes.
+	
+@---------------------------------------------------------------------------------
+@ Text identifier - can be anything up to 47 chars + terminating null -- 16 bytes
+	.align	4
+	.asciz "Default (No interface)"
+
+@---------------------------------------------------------------------------------
+@ Offsets to important sections within the data	-- 32 bytes
+	.align	6
+	.word   dldi_start		@ data start
+	.word   dldi_end		@ data end
+	.word	0x00000000		@ Interworking glue start	-- Needs address fixing
+	.word	0x00000000		@ Interworking glue end
+	.word   0x00000000		@ GOT start					-- Needs address fixing
+	.word   0x00000000		@ GOT end
+	.word   0x00000000		@ bss start					-- Needs setting to zero
+	.word   0x00000000		@ bss end
+
+@---------------------------------------------------------------------------------
+@ DISC_INTERFACE data -- 32 bytes
+	.ascii	"DLDI"				@ ioType
+	.word	0x00000000			@ Features
+	.word	_DLDI_startup			@ 
+	.word	_DLDI_isInserted		@ 
+	.word	_DLDI_readSectors		@   Function pointers to standard device driver functions
+	.word	_DLDI_writeSectors		@ 
+	.word	_DLDI_clearStatus		@ 
+	.word	_DLDI_shutdown			@ 
+	
+@---------------------------------------------------------------------------------
+
+_DLDI_startup:
+_DLDI_isInserted:
+_DLDI_readSectors:
+_DLDI_writeSectors:
+_DLDI_clearStatus:
+_DLDI_shutdown:
+	mov		r0, #0x00				@ Return false for every function
+	bx		lr
+
+
+
+@---------------------------------------------------------------------------------
+	.align
+	.pool
+
+dldi_data_end:
+
+@ Pad to end of allocated space
+.space DLDI_ALLOCATED_SPACE - (dldi_data_end - dldi_start)	
+
+dldi_end:
+	.end
+@---------------------------------------------------------------------------------


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

For whatever reason, this actually works. By copying the original stub from libnds v1.8.3, and specifying 32KiB, the final build retains the 32KiB DLDI allocated space without having to hack the library itself.

This also removes the need for a custom fork of libnds.

Test: observe empty area with a hex editor

#### Where have you tested it?

DS Lite, DSTT with M3 Expansion Pak

***

#### Pull Request status
- [ ] This PR has been tested using the latest version of devkitARM and libnds.
