### PR TITLE
Explicitly check for the extra ram to be available and working when running off a SuperCard

### DIFF
--- a/retail/arm9/source/conf_sd.cpp
+++ b/retail/arm9/source/conf_sd.cpp
@@ -805,7 +805,11 @@ int loadFromSD(configuration* conf, const char *bootstrapPath) {
 				} else if (memcmp(io_dldi_data->friendlyName, "G6", 2) == 0) {
 					*(u16*)(0x020000C0) = 0x3647;
 				} else if (memcmp(io_dldi_data->friendlyName, "SuperCard", 9) == 0 || memcmp(io_dldi_data->friendlyName, "SCSD", 4) == 0) {
-					*(u16*)(0x020000C0) = 0x4353;
+					_SC_changeMode(SC_MODE_RAM);
+					*(vu16*)(0x08000000) = 0x4D54;
+					if(*(vu16*)(0x08000000) == 0x4D54) {
+						*(u16*)(0x020000C0) = 0x4353;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
The SuperCard Rumble was being detected as "SuperCard" and assumed the extra ram was available, but that cart got no such memory, it's not an issue that the supercard mode is changed because the official dldi as well will set the card to an appropriate mode when performing operations