### PR TITLE
add Special Card support for using Direction Sensor from 星空ナビ(Hoshizora Navi) Card (NTR-UEIJ-JPN)

### DIFF
--- a/retail/arm9/source/conf_sd.cpp
+++ b/retail/arm9/source/conf_sd.cpp
@@ -1450,7 +1450,7 @@ int loadFromSD(configuration* conf, const char *bootstrapPath) {
 		fclose(donorNdsFile);
 
 		if (!conf->gameOnFlashcard && !conf->saveOnFlashcard) {
-			if (romTid[0] != 'I' && memcmp(romTid, "UZP", 3) != 0 && memcmp(romTid, "HND", 3) != 0) {
+			if (romTid[0] != 'I' && memcmp(romTid, "UZP", 3) != 0 && memcmp(romTid, "HND", 3) != 0 && memcmp(romTid, "UEI", 3) != 0) {
 				disableSlot1();
 			} else {
 				// Initialize card and read header, HGSS IR doesn't work if you don't read the full header
@@ -1505,8 +1505,8 @@ int loadFromSD(configuration* conf, const char *bootstrapPath) {
 
 				sysSetCardOwner(BUS_OWNER_ARM7);
 
-				// Leave Slot-1 enabled for IR cartridges, Battle & Get: Pokémon Typing DS, and DS Download Play
-				conf->specialCard = (headerData[0xC] == 'I' || memcmp(headerData + 0xC, "UZP", 3) == 0 || memcmp(romTid, "HND", 3) == 0);
+				// Leave Slot-1 enabled for IR cartridges, Battle & Get: Pokémon Typing DS, DS Download Play, and Hoshizora Navi (Direction Sensing Card)
+				conf->specialCard = (headerData[0xC] == 'I' || memcmp(headerData + 0xC, "UZP", 3) == 0 || memcmp(romTid, "HND", 3) == 0 || memcmp(romTid, "UEI", 3) == 0);
 				if (conf->specialCard) {
 					conf->valueBits2 |= BIT(4);
 				} else {


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

add codes to detect special card 星空ナビ(Hoshizora Navi) (NTR-UEIJ-JPN) (No-Intro number 4132) and enable to use card's Direction Sensor.

https://github.com/user-attachments/assets/0359c246-c433-4f5e-a8b0-8d5fdeb4564e

#### Where have you tested it?

DSiLL(1.4.5J, unlaunchv2.0), 
OLD 3DS(11.17.0-50J, b9s1.4, luma13.3)

***

#### Pull Request status
 This PR has been tested using the version of devkitARM and libnds in the latest workflow of github action.
