### PR TITLE
add debug print  for save relocation in B4DS mode

### DIFF
--- a/retail/arm9/source/main.cpp
+++ b/retail/arm9/source/main.cpp
@@ -184,6 +184,7 @@ static inline void debugConfB4DS(configuration* conf) {
 	dbg_printf("logging: %s\n", btoa(conf->logging));
 	dbg_printf("initDisc: %s\n", btoa(conf->initDisc));
 	dbg_printf("macroMode: %s\n", btoa(conf->macroMode));
+	dbg_printf("saveRelocation: %s\n", btoa(conf->saveRelocation));
 }
 
 static inline void debugConf(configuration* conf) {


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

add debug print  for save relocation in B4DS mode. 
(dbg_print in DSi mode has already been added.)


***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
