### PR TITLE
Adjust race condition fix for Akumajou Dracula - Gallery of Labyrinth (Rev 1)

### DIFF
--- a/retail/bootloader/source/arm7/patch_common.c
+++ b/retail/bootloader/source/arm7/patch_common.c
@@ -118,10 +118,10 @@ void patchBinary(cardengineArm9* ce9, const tNDSHeader* ndsHeader, module_params
 			*(u32*)0x02007a10 += 0xe0000000; // mlaeq -> mla
 			*(u32*)0x02007a14 += 0xe0000000; // beq -> b
 		} else {
-			*(u32*)0x0200753C += 5;
-			*(u32*)0x02007544 += 0xd0000000; // bne -> b
-			*(u32*)0x02007624 += 5;
-			*(u32*)0x0200762C += 0xd0000000; // bne -> b
+			*(u32*)0x0200753C = 0xeb023286; // OS_JoinThread()
+			*(u32*)0x02007540 = 0xe1500000; // cmp r0, r0
+			*(u32*)0x02007624 = 0xeb02324c; // OS_JoinThread()
+			*(u32*)0x0200762C = 0xe35f0000; // cmp pc, #0
 		}
 	}
 

--- a/retail/bootloader/source/arm7/patch_common.c
+++ b/retail/bootloader/source/arm7/patch_common.c
@@ -121,7 +121,7 @@ void patchBinary(cardengineArm9* ce9, const tNDSHeader* ndsHeader, module_params
 			*(u32*)0x0200753C = 0xeb023286; // OS_JoinThread()
 			*(u32*)0x02007540 = 0xe1500000; // cmp r0, r0
 			*(u32*)0x02007624 = 0xeb02324c; // OS_JoinThread()
-			*(u32*)0x0200762C = 0xe35f0000; // cmp pc, #0
+			*(u32*)0x02007628 = 0xe35f0000; // cmp pc, #0
 		}
 	}
 

--- a/retail/bootloaderi/source/arm7/patch_common.c
+++ b/retail/bootloaderi/source/arm7/patch_common.c
@@ -16429,7 +16429,7 @@ void patchBinary(cardengineArm9* ce9, const tNDSHeader* ndsHeader, module_params
 			*(u32*)0x0200753C = 0xeb023286; // OS_JoinThread()
 			*(u32*)0x02007540 = 0xe1500000; // cmp r0, r0
 			*(u32*)0x02007624 = 0xeb02324c; // OS_JoinThread()
-			*(u32*)0x0200762C = 0xe35f0000; // cmp pc, #0
+			*(u32*)0x02007628 = 0xe35f0000; // cmp pc, #0
 		}
 	}
 

--- a/retail/bootloaderi/source/arm7/patch_common.c
+++ b/retail/bootloaderi/source/arm7/patch_common.c
@@ -16426,10 +16426,10 @@ void patchBinary(cardengineArm9* ce9, const tNDSHeader* ndsHeader, module_params
 			*(u32*)0x02007a10 += 0xe0000000; // mlaeq -> mla
 			*(u32*)0x02007a14 += 0xe0000000; // beq -> b
 		} else {
-			*(u32*)0x0200753C += 5;
-			*(u32*)0x02007544 += 0xd0000000; // bne -> b
-			*(u32*)0x02007624 += 5;
-			*(u32*)0x0200762C += 0xd0000000; // bne -> b
+			*(u32*)0x0200753C = 0xeb023286; // OS_JoinThread()
+			*(u32*)0x02007540 = 0xe1500000; // cmp r0, r0
+			*(u32*)0x02007624 = 0xeb02324c; // OS_JoinThread()
+			*(u32*)0x0200762C = 0xe35f0000; // cmp pc, #0
 		}
 	}
 


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

The fix for the multithreading race condition in *Akumajou Dracula - Gallery of Labyrinth (Rev 1)* was changed to one that I originally wrote for pico-loader. Calls to `OS_IsThreadTerminated` are replaced with ones to `OS_JoinThread`, and the subsequent compare of the return is changed accordingly.

Fixes #1945 

#### Where have you tested it?

The build from GH actions was tested on my CFW original 3DS; also, the user that opened the issue confirmed it was working for them.

***

#### Pull Request status
- [ ] This PR has been tested using the latest version of devkitARM and libnds.
